### PR TITLE
refactor: replace :has-text for step circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,13 +109,7 @@
       }
       
       /* Fix green circle backgrounds for numbered steps */
-      .step-number, 
-      [class*="step"], 
-      [class*="number"],
-      div[style*="background-color: rgb(34, 197, 94)"],
-      div[style*="background-color: #22c55e"],
-      div[style*="background: rgb(34, 197, 94)"],
-      div[style*="background: #22c55e"] {
+      .step[data-step] {
         width: 60px !important;
         height: 60px !important;
         border-radius: 50% !important;
@@ -127,26 +121,9 @@
         min-height: 60px !important;
         max-width: 60px !important;
         max-height: 60px !important;
+        aspect-ratio: 1 / 1 !important;
       }
-      
-      /* Target all green background elements that might contain numbers */
-      div[style*="background"]:has-text("1"),
-      div[style*="background"]:has-text("2"), 
-      div[style*="background"]:has-text("3"),
-      div[style*="background"]:has-text("4"),
-      span[style*="background"]:has-text("1"),
-      span[style*="background"]:has-text("2"),
-      span[style*="background"]:has-text("3"),
-      span[style*="background"]:has-text("4") {
-        border-radius: 50% !important;
-        width: 60px !important;
-        height: 60px !important;
-        min-width: 60px !important;
-        min-height: 60px !important;
-        max-width: 60px !important;
-        max-height: 60px !important;
-      }
-      
+
       /* Fix for numbered step circles to maintain perfect circular shape */
       .bg-green-600.text-white.rounded-full.w-8.h-8.flex.items-center.justify-center.font-bold {
         min-width: 32px !important;
@@ -169,36 +146,26 @@
       function fixGreenCircles() {
         // Find all elements that might contain numbered steps
         const allElements = document.querySelectorAll('*');
-        
+
         allElements.forEach(element => {
           const computedStyle = window.getComputedStyle(element);
           const bgColor = computedStyle.backgroundColor;
-          
+
           // Check if element has green background (various shades of green)
-          if (bgColor.includes('rgb(34, 197, 94)') || 
-              bgColor.includes('rgb(22, 163, 74)') || 
+          if (bgColor.includes('rgb(34, 197, 94)') ||
+              bgColor.includes('rgb(22, 163, 74)') ||
               bgColor.includes('rgb(16, 185, 129)') ||
               bgColor.includes('#22c55e') ||
               bgColor.includes('#16a34a') ||
               bgColor.includes('#10b981')) {
-            
+
             // Check if element contains a number (1, 2, 3, or 4)
             const text = element.textContent.trim();
             if (text === '1' || text === '2' || text === '3' || text === '4') {
-              // Force perfect circle
-              element.style.width = '60px';
-              element.style.height = '60px';
-              element.style.minWidth = '60px';
-              element.style.minHeight = '60px';
-              element.style.maxWidth = '60px';
-              element.style.maxHeight = '60px';
-              element.style.borderRadius = '50%';
-              element.style.display = 'flex';
-              element.style.alignItems = 'center';
-              element.style.justifyContent = 'center';
-              element.style.flexShrink = '0';
-              element.style.aspectRatio = '1/1';
-              
+              // Apply class and data attribute for styling instead of :has-text
+              element.classList.add('step');
+              element.setAttribute('data-step', text);
+
               console.log(`Fixed circle for number: ${text}`);
             }
           }


### PR DESCRIPTION
## Summary
- remove `:has-text` selectors from inline styles
- add JavaScript that tags green-number elements with `step` and `data-step`
- style numbered steps via `.step[data-step]` for cross-browser support

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f1a2c400832b8154853e9815d64d