### PR TITLE
Add meta descriptions to legal pages

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -12,6 +12,7 @@
     <link rel="shortcut icon" href="favicon.ico?v=1750774954">
     <meta name="msapplication-TileImage" content="favicon.png?v=1750774954">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Review how Revive collects, uses, and safeguards your data when you visit our site or use our services, and understand your privacy rights and choices.">
     <title>Privacy Policy - Revive</title>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -12,6 +12,7 @@
     <link rel="shortcut icon" href="favicon.ico?v=1750774954">
     <meta name="msapplication-TileImage" content="favicon.png?v=1750774954">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Read the terms governing access to Revive's AI-driven sales services, including service use, client responsibilities, fees, and limitations of liability.">
     <title>Terms & Conditions - Revive</title>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>


### PR DESCRIPTION
## Summary
- add descriptive meta description tags to privacy policy and terms & conditions pages for improved SEO

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f351a244832bb2be85dc339b4cd1