### PR TITLE
Add canonical links to HTML pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Turn wasted leads into revenue. Our AI Sales Agent re-engages cold prospects, books real sales calls automatically, and helps you close more without chasing.">
     <title>AI Sales Agent | Reactivate Cold Leads Into Booked Sales Calls | Revive</title>
+    <link rel="canonical" href="https://revivesales.ai/">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
     <script>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Review how Revive collects, uses, and safeguards your data when you visit our site or use our services, and understand your privacy rights and choices.">
     <title>Privacy Policy - Revive</title>
+    <link rel="canonical" href="https://revivesales.ai/privacy-policy.html">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
     <script>

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Read the terms governing access to Revive's AI-driven sales services, including service use, client responsibilities, fees, and limitations of liability.">
     <title>Terms & Conditions - Revive</title>
+    <link rel="canonical" href="https://revivesales.ai/terms-conditions.html">
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
     <script>


### PR DESCRIPTION
## Summary
- add canonical links referencing revivesales.ai for index, privacy policy, and terms pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f4cfaf98832b9e85ad621347d57f