### PR TITLE
chore: add linting configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "website",
+  "version": "1.0.0",
+  "description": "This repository contains the official website for Revive Sales - an AI-powered lead reactivation service that turns dead leads into booked sales calls.",
+  "main": "index.js",
+  "scripts": {
+    "lint:html": "htmlhint '**/*.html'",
+    "lint:js": "eslint assets/**/*.js",
+    "lint:css": "stylelint '**/*.css'",
+    "test": "npm run lint:html && npm run lint:js && npm run lint:css"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "htmlhint": "*",
+    "eslint": "*",
+    "stylelint": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with linting scripts for HTML, JS, and CSS

## Testing
- `npm install --save-dev htmlhint eslint stylelint` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm test` *(fails: htmlhint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ef5eef70832bbba5436d30086db3