### PR TITLE
Add roadmap link to policy and terms headers

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -63,6 +63,7 @@
               <a href="./index.html#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
               <a href="./index.html#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
               <a href="./index.html#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
+              <a href="./index.html#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
             </nav>
             <a href="./index.html#contact">
               <button class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-colors">

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -63,6 +63,7 @@
               <a href="./index.html#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
               <a href="./index.html#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
               <a href="./index.html#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
+              <a href="./index.html#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
             </nav>
             <a href="./index.html#contact">
               <button class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-colors">


### PR DESCRIPTION
## Summary
- add "Your Roadmap" link to header navigation on privacy policy and terms pages

## Testing
- `npm test` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68c71fb2bb80832bb1a651715ab21d6d