### PR TITLE
feat: add shared header and footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,15 +2,19 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Landing from './pages/Landing';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import Terms from './pages/Terms';
+import Header from './components/Header';
+import Footer from './components/Footer';
 
 function App() {
   return (
     <Router>
+      <Header />
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/terms" element={<Terms />} />
       </Routes>
+      <Footer />
     </Router>
   );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+export default function Footer() {
+  return (
+    <footer>
+      <nav>
+        <ul>
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/privacy">Privacy</Link></li>
+          <li><Link to="/terms">Terms</Link></li>
+          {/* Custom contact link: renamed to avoid 'Contact' wording */}
+          <li><a href="mailto:info@example.com">Get in Touch</a></li>
+        </ul>
+      </nav>
+    </footer>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+
+export default function Header() {
+  return (
+    <header>
+      <nav>
+        <ul>
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/privacy">Privacy</Link></li>
+          <li><Link to="/terms">Terms</Link></li>
+          {/* Custom contact link: renamed to avoid 'Contact' wording */}
+          <li><a href="mailto:info@example.com">Get in Touch</a></li>
+        </ul>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add Header and Footer components with shared nav links
- include custom "Get in Touch" link instead of default Contact link
- integrate Header and Footer into root App layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c72c91767c832ba99bc6104afe32f8