### PR TITLE
Add dedicated privacy and terms pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The website is automatically deployed to GitHub Pages at: **https://revivesales.
 ## 📋 Features
 
 - **Professional Landing Page**: Clean, modern design based on industry best practices
-- **Routing**: Landing, Privacy Policy, and Terms pages powered by React Router
+- **Routing**: Landing, Privacy Policy, and Terms & Conditions pages powered by React Router
 - **Responsive Design**: Optimized for desktop and mobile devices
 
 ## 🛠 Technology Stack

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,6 +10,6 @@ Disallow: /node_modules/
 Disallow: /*.json$
 
 # Disallow crawling of legal pages
-Disallow: /privacy-policy.html
-Disallow: /terms-conditions.html
+Disallow: /privacy
+Disallow: /terms-conditions
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -7,13 +7,13 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://revivesales.ai/privacy-policy.html</loc>
+    <loc>https://revivesales.ai/privacy</loc>
     <lastmod>2025-06-30T01:39:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://revivesales.ai/terms-conditions.html</loc>
+    <loc>https://revivesales.ai/terms-conditions</loc>
     <lastmod>2025-06-30T01:39:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Landing from './pages/Landing';
 import PrivacyPolicy from './pages/PrivacyPolicy';
-import Terms from './pages/Terms';
+import TermsConditions from './pages/TermsConditions';
 import Header from './components/Header';
 import Footer from './components/Footer';
 
@@ -12,7 +12,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
-        <Route path="/terms" element={<Terms />} />
+        <Route path="/terms-conditions" element={<TermsConditions />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,7 +7,7 @@ export default function Footer() {
         <ul>
           <li><Link to="/">Home</Link></li>
           <li><Link to="/privacy">Privacy</Link></li>
-          <li><Link to="/terms">Terms</Link></li>
+          <li><Link to="/terms-conditions">Terms &amp; Conditions</Link></li>
           {/* Custom contact link: renamed to avoid 'Contact' wording */}
           <li><a href="mailto:info@example.com">Get in Touch</a></li>
         </ul>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,7 +7,7 @@ export default function Header() {
         <ul>
           <li><Link to="/">Home</Link></li>
           <li><Link to="/privacy">Privacy</Link></li>
-          <li><Link to="/terms">Terms</Link></li>
+          <li><Link to="/terms-conditions">Terms &amp; Conditions</Link></li>
           {/* Custom contact link: renamed to avoid 'Contact' wording */}
           <li><a href="mailto:info@example.com">Get in Touch</a></li>
         </ul>

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,8 +1,32 @@
 export default function PrivacyPolicy() {
   return (
-    <main>
+    <main className="policy-container">
       <h1>Privacy Policy</h1>
-      <p>This is our privacy policy.</p>
+      <p>Last updated: January 1, 2025</p>
+
+      <section>
+        <h2>Information We Collect</h2>
+        <p>
+          We collect information that you provide directly to us when you use our
+          services or communicate with us.
+        </p>
+      </section>
+
+      <section>
+        <h2>How We Use Information</h2>
+        <p>
+          The information we collect is used to provide, maintain, and improve our
+          services, as well as to communicate with you.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact Us</h2>
+        <p>
+          If you have questions about this Privacy Policy, please email
+          info@example.com.
+        </p>
+      </section>
     </main>
   );
 }

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -1,8 +1,0 @@
-export default function Terms() {
-  return (
-    <main>
-      <h1>Terms and Conditions</h1>
-      <p>These are our terms and conditions.</p>
-    </main>
-  );
-}

--- a/src/pages/TermsConditions.jsx
+++ b/src/pages/TermsConditions.jsx
@@ -1,0 +1,32 @@
+export default function TermsConditions() {
+  return (
+    <main className="terms-container">
+      <h1>Terms & Conditions</h1>
+      <p>Last updated: January 1, 2025</p>
+
+      <section>
+        <h2>Acceptance of Terms</h2>
+        <p>
+          By accessing and using this website, you accept and agree to be bound
+          by the terms and provision of this agreement.
+        </p>
+      </section>
+
+      <section>
+        <h2>Use of the Service</h2>
+        <p>
+          You agree not to misuse the service or help anyone else do so. The
+          service should only be used for lawful purposes.
+        </p>
+      </section>
+
+      <section>
+        <h2>Contact Us</h2>
+        <p>
+          If you have any questions about these Terms, please email
+          info@example.com.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add structured Privacy Policy and Terms & Conditions pages
- update routing, navigation, sitemap, and robots entries for new routes
- document new pages in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found; dependencies installation blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c72d44bdb4832bb67af0a8f93bdcf6