### PR TITLE
Prevent duplicate roadmap replacements

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
         while (walker.nextNode()) {
           const node = walker.currentNode;
           replacements.forEach(r => {
-            if (node.nodeValue.includes(r.old)) {
+            if (node.nodeValue.includes(r.old) && !node.nodeValue.includes(r.new)) {
               node.nodeValue = node.nodeValue.replace(r.old, r.new);
             }
           });


### PR DESCRIPTION
## Summary
- Guard against repeated text substitutions to stop duplicated roadmap items like "Free Free Free Pilot"

## Testing
- `npm test` *(fails: ESLint couldn't find eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c76cdf52a8832bb4a9be78c297412e