### PR TITLE
Add static index page without JavaScript

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <link rel="icon" type="image/x-icon" href="favicon.ico?v=1750774954">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon.png?v=1750774954">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=1750774954">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon.png?v=1750774954">
+    <link rel="shortcut icon" href="favicon.ico?v=1750774954">
+    <meta name="msapplication-TileImage" content="favicon.png?v=1750774954">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Turn wasted leads into revenue. Our AI Sales Agent re-engages cold prospects, books real sales calls automatically, and helps you close more without chasing.">
+    <title>AI Sales Agent | Reactivate Cold Leads Into Booked Sales Calls | Revive</title>
+    <link rel="canonical" href="https://revivesales.ai/">
+    <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
+    <style>
+      /* Override header shrinking when sticky */
+      header,
+      nav,
+      [role="banner"],
+      .sticky,
+      [class*="header"],
+      [class*="Header"],
+      [class*="nav"],
+      [class*="Nav"] {
+        min-height: 60px !important;
+        padding-top: 0.75rem !important;
+        padding-bottom: 0.75rem !important;
+        transition: none !important;
+      }
+
+      /* Ensure header elements maintain size when sticky */
+      header.sticky,
+      nav.sticky,
+      [role="banner"].sticky,
+      .sticky header,
+      .sticky nav,
+      [class*="header"].sticky,
+      [class*="Header"].sticky,
+      [class*="nav"].sticky,
+      [class*="Nav"].sticky {
+        min-height: 60px !important;
+        height: auto !important;
+        padding-top: 0.75rem !important;
+        padding-bottom: 0.75rem !important;
+        padding-left: 1rem !important;
+        padding-right: 1rem !important;
+        transform: none !important;
+        scale: 1 !important;
+        transition: none !important;
+      }
+
+      /* Prevent any transform or scale changes */
+      header *,
+      nav *,
+      [role="banner"] *,
+      .sticky *,
+      [class*="header"] *,
+      [class*="Header"] *,
+      [class*="nav"] *,
+      [class*="Nav"] * {
+        transform: none !important;
+        scale: 1 !important;
+      }
+
+      /* Force specific padding classes to maintain reasonable size */
+      .p-0, .p-1, .p-2, .p-3, .p-4, .p-6, .p-8,
+      .px-0, .px-1, .px-2, .px-3, .px-4, .px-6, .px-8,
+      .py-0, .py-1, .py-2, .py-3, .py-4, .py-6, .py-8 {
+        padding: 0.75rem !important;
+      }
+
+      /* Ensure header stays below banner */
+      header,
+      nav,
+      [role="banner"],
+      .sticky {
+        z-index: 50 !important;
+        top: 45px !important; /* Account for banner height */
+      }
+
+      body {
+        padding-top: 45px; /* Space for fixed banner */
+      }
+
+      @media (max-width: 768px) {
+        header,
+        nav,
+        [role="banner"],
+        .sticky {
+          top: 55px !important; /* Account for mobile banner height */
+        }
+
+        body {
+          padding-top: 55px; /* Space for mobile banner */
+        }
+      }
+
+      /* Fix green circle backgrounds for numbered steps */
+      .step[data-step] {
+        width: 60px !important;
+        height: 60px !important;
+        border-radius: 50% !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        flex-shrink: 0 !important;
+        min-width: 60px !important;
+        min-height: 60px !important;
+        max-width: 60px !important;
+        max-height: 60px !important;
+        aspect-ratio: 1 / 1 !important;
+      }
+
+      /* Fix for numbered step circles to maintain perfect circular shape */
+      .bg-green-600.text-white.rounded-full.w-8.h-8.flex.items-center.justify-center.font-bold {
+        min-width: 32px !important;
+        max-width: 32px !important;
+        width: 32px !important;
+        min-height: 32px !important;
+        max-height: 32px !important;
+        height: 32px !important;
+        flex-shrink: 0 !important;
+        flex-grow: 0 !important;
+        box-sizing: border-box !important;
+      }
+    </style>
+  </head>
+  <body class="min-h-screen bg-white">
+    <div id="promotional-banner" style="position:fixed;top:0;left:0;right:0;z-index:9999;background:linear-gradient(135deg,#16a34a 0%,#15803d 100%);color:white;text-align:center;padding:12px 20px;font-weight:600;font-size:14px;line-height:1.4;">
+      🚀 Up to 80% of your pipeline goes cold — Ava brings those leads back as booked sales calls fast! <a href="#contact" style="font-weight:bold;text-decoration:underline;">Talk to Ava Now →</a>
+    </div>
+    <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex justify-between items-center h-16">
+          <div class="flex items-center">
+            <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto" />
+          </div>
+          <nav class="hidden md:flex space-x-8">
+            <a href="#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
+            <a href="#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
+            <a href="#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
+            <a href="#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
+            <a href="#contact" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
+          </nav>
+          <a href="#contact" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded">Get Started</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="relative bg-gradient-to-br from-green-50 to-white py-20 lg:py-32">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">Stop Losing Deals to <span class="text-green-600">Dead Leads!</span></h1>
+            <p class="text-xl text-gray-600 mb-8 leading-relaxed">Your leads aren't dead — they're just waiting. Ava, your AI sales agent, re-engages forgotten prospects and books qualified calls automatically. Start with a free pilot, prove it on your own pipeline.</p>
+            <div class="flex flex-col sm:flex-row gap-4">
+              <a href="#contact" class="bg-green-600 hover:bg-green-700 text-white px-8 py-4 text-lg w-full text-center rounded">Revive My Leads</a>
+              <a href="#about" class="border-green-600 text-green-600 hover:bg-green-50 px-8 py-4 text-lg w-full text-center rounded">Try Ava Free →</a>
+            </div>
+          </div>
+          <div class="relative">
+            <img src="/assets/business-call-2-DzwsVybZ.jpg" alt="Professional business communication" class="rounded-2xl shadow-2xl w-full" />
+            <div class="absolute -bottom-6 -left-6 bg-white p-4 rounded-xl shadow-lg border">
+              <div class="flex items-center space-x-3">
+                <svg class="h-8 w-8 text-green-600" aria-hidden="true"></svg>
+                <div>
+                  <p class="font-semibold text-gray-900">AI Agent Active</p>
+                  <p class="text-sm text-gray-600">Engaging 12476 leads</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="about" class="py-20 bg-white">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-16">
+          <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-6">Turn the 80% of Leads You're Losing Into Revenue</h2>
+          <p class="text-xl text-gray-600 max-w-3xl mx-auto">Most sales teams close less than 20% of their leads — Ava reactivates the rest and puts booked sales calls on your calendar.</p>
+        </div>
+        <div class="grid md:grid-cols-3 gap-8">
+          <div class="border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div class="p-8 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-xl font-semibold text-gray-900 mb-3">Reactivate Cold Leads</h3>
+              <p class="text-gray-600">Ava re-engages forgotten prospects with human-like conversations that spark replies.</p>
+            </div>
+          </div>
+          <div class="border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div class="p-8 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-xl font-semibold text-gray-900 mb-3">Book Appointments Automatically</h3>
+              <p class="text-gray-600">When leads respond, Ava schedules them straight onto your team's calendar.</p>
+            </div>
+          </div>
+          <div class="border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div class="p-8 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-xl font-semibold text-gray-900 mb-3">No Risk, Results First</h3>
+              <p class="text-gray-600">You don't pay until results are delivered. We prove value with a no-risk pilot program.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="how-it-works" class="py-20 bg-gray-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-16">
+          <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-6">"Dead leads aren't dead — they're just waiting for the right conversation"</h2>
+        </div>
+        <div class="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <img src="/assets/ai-tech-1-CNBe3GGX.jpg" alt="AI Technology in Business" class="rounded-2xl shadow-xl w-full" />
+          </div>
+          <div class="space-y-8">
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">1</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">We Upload Your Cold Leads</h3>
+                <p class="text-gray-600">Simply share your dormant lead list or CRM export — we handle the rest.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">2</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Ava Reaches Out via SMS Text Messages</h3>
+                <p class="text-gray-600">Your AI sales agent re-engages prospects with natural, human-like text conversations.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">3</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Qualified Prospects Get Booked</h3>
+                <p class="text-gray-600">When they're qualified and show interest, Ava schedules appointments directly to your calendar.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">4</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">You Get Sales-Ready Meetings</h3>
+                <p class="text-gray-600">Qualified, hot prospects show up ready for your sales team to close.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="industries" class="py-20 bg-white">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-16">
+          <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-6">Built for High-Value Service Businesses</h2>
+          <p class="text-xl text-gray-600 max-w-3xl mx-auto">Revive works best with businesses that rely on lead generation and sell relationship-based services.</p>
+        </div>
+        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">Insurance Agencies</h3>
+              <p class="text-gray-600">Re-engage prospects who didn't convert initially</p>
+            </div>
+          </div>
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">Real Estate Teams</h3>
+              <p class="text-gray-600">Turn cold leads into property viewings</p>
+            </div>
+          </div>
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">Medical & Dental</h3>
+              <p class="text-gray-600">Book consultations with interested patients</p>
+            </div>
+          </div>
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">Home Services</h3>
+              <p class="text-gray-600">Convert estimates into scheduled services</p>
+            </div>
+          </div>
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">Coaches & Consultants</h3>
+              <p class="text-gray-600">Book discovery calls with potential clients</p>
+            </div>
+          </div>
+          <div class="hover:shadow-lg transition-shadow">
+            <div class="p-6 text-center">
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <h3 class="text-lg font-semibold text-gray-900 mb-2">High-Ticket eCommerce</h3>
+              <p class="text-gray-600">Schedule sales calls for premium products</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="testimonials" class="py-20 bg-gray-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-16">
+          <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-6">What Our Clients Say</h2>
+        </div>
+        <div class="grid md:grid-cols-3 gap-8">
+          <div class="p-6 bg-white rounded shadow">
+            <p class="text-gray-600 mb-4">"Ava revived more leads in a week than our team did in months."</p>
+            <p class="font-semibold text-gray-900">— Happy Customer</p>
+          </div>
+          <div class="p-6 bg-white rounded shadow">
+            <p class="text-gray-600 mb-4">"The booked calls started rolling in almost immediately."</p>
+            <p class="font-semibold text-gray-900">— Sales Manager</p>
+          </div>
+          <div class="p-6 bg-white rounded shadow">
+            <p class="text-gray-600 mb-4">"We closed deals we thought were long gone."</p>
+            <p class="font-semibold text-gray-900">— Agency Owner</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="roadmap" class="py-20 bg-gray-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid lg:grid-cols-2 gap-12 items-start">
+          <div class="space-y-8">
+            <div class="text-center lg:text-left mb-12">
+              <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-4">Your Roadmap to Booked Calls</h2>
+              <p class="text-xl text-gray-600">From first text to full-scale reactivation — here's how your journey with Ava works.</p>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">1</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Try Ava</h3>
+                <p class="text-gray-600">Fill out the form and Ava texts you instantly, starting a SPIN sales conversation.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">2</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Demo</h3>
+                <p class="text-gray-600">Get a live, bespoke demo showing Ava booking calls for your business.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">3</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Pilot</h3>
+                <p class="text-gray-600">We'll contact up to 1,000 of your dead leads for free and book sales calls directly to your calendar.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">4</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Sign-Up</h3>
+                <p class="text-gray-600">Love the results? Scale with us on a pay-for-performance model.</p>
+              </div>
+            </div>
+            <div class="flex items-start space-x-4">
+              <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">5</div>
+              <div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Connect New Leads</h3>
+                <p class="text-gray-600">After reviving old leads, Ava also works on your new, incoming leads</p>
+              </div>
+            </div>
+          </div>
+          <div class="lg:order-last">
+            <img src="/assets/business-consultation.jpg" alt="Professional Business Consultation" class="rounded-2xl shadow-xl w-full" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="py-20 bg-gradient-to-br from-green-600 to-green-700">
+      <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-12">
+          <h2 class="text-3xl lg:text-5xl font-bold text-white mb-6">See what Ava, our AI Sales Agent, can do for your Leads! Try it now:</h2>
+          <p class="text-xl text-green-100">Text with our AI Sales Agent to book a call and apply for a 100% free trial to revive your cold leads!</p>
+        </div>
+        <div class="max-w-2xl mx-auto p-8 bg-white rounded">
+          <iframe src="https://api.leadconnectorhq.com/widget/form/PE0cLAAGSrmxmmimaMRt" style="width:100%;height:565px;border:none;border-radius:3px" id="inline-PE0cLAAGSrmxmmimaMRt" data-layout="{'id':'INLINE'}" data-trigger-type="alwaysShow" data-trigger-value="" data-activation-type="alwaysActivated" data-activation-value="" data-deactivation-type="neverDeactivate" data-deactivation-value="" data-form-name="Form 1" data-height="565" data-layout-iframe-id="inline-PE0cLAAGSrmxmmimaMRt" data-form-id="PE0cLAAGSrmxmmimaMRt" title="Form 1"></iframe>
+        </div>
+      </div>
+    </section>
+
+    <footer class="bg-gray-900 text-white py-12">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid md:grid-cols-4 gap-8">
+          <div>
+            <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto mb-4 filter brightness-0 invert" />
+            <p class="text-gray-400">Turn dead leads into booked sales calls with AI-powered conversations.</p>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">Company</h3>
+            <ul class="space-y-2 text-gray-400">
+              <li><a href="#" class="hover:text-white transition-colors">About</a></li>
+              <li><a href="#" class="hover:text-white transition-colors">How It Works</a></li>
+              <li><a href="#" class="hover:text-white transition-colors">Industries</a></li>
+              <li><a href="#" class="hover:text-white transition-colors">Your Roadmap</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">Support</h3>
+            <ul class="space-y-2 text-gray-400">
+              <li><a href="#contact" class="hover:text-white transition-colors">Contact</a></li>
+              <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
+              <li><a href="terms-conditions.html" class="hover:text-white transition-colors">Terms &amp; Conditions</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">Contact</h3>
+            <a href="#contact" class="text-gray-400 hover:text-white transition-colors">Ready to revive your leads?<br/>Get started today.</a>
+          </div>
+        </div>
+        <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
+          <p>© 2025 RapidDev Solutions Inc. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Duplicate index.html into index2.html and remove root React mount and scripts
- Embed static markup for hero, feature grid, how-it-works steps, industries, roadmap, contact form, and footer
- Retain existing metadata and stylesheet so page renders without client-side JavaScript
- Restore fixed promotional banner and adjust layout to account for its height

## Testing
- `npm test` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run lint:html`
- `npm run lint:css` *(fails: No configuration provided for stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68c76c146e5c832bb060f13fa26f5208