### PR TITLE
feat: widen roadmap heading

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -354,12 +354,12 @@
 
     <section id="roadmap" class="py-20 bg-gray-50">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="text-center mb-16">
+          <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-4">Your Roadmap to Booked Calls</h2>
+          <p class="text-xl text-gray-600">From first text to full-scale reactivation — here's how your journey with Ava works.</p>
+        </div>
         <div class="grid lg:grid-cols-2 gap-12 items-start">
           <div class="space-y-8">
-            <div class="text-center lg:text-left mb-12">
-              <h2 class="text-3xl lg:text-5xl font-bold text-gray-900 mb-4">Your Roadmap to Booked Calls</h2>
-              <p class="text-xl text-gray-600">From first text to full-scale reactivation — here's how your journey with Ava works.</p>
-            </div>
             <div class="flex items-start space-x-4">
               <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">1</div>
               <div>


### PR DESCRIPTION
## Summary
- Move roadmap header and subheader into a full-width container so text spans both columns

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm test` *(fails: htmlhint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77856563c832b858f395cddcffc75