### PR TITLE
Add white background to Try Ava Free CTA

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -188,7 +188,7 @@
             <p class="text-xl text-gray-600 mb-8 leading-relaxed">Your leads aren't dead — they're just waiting. Ava, your AI sales agent, re-engages forgotten prospects and books qualified calls automatically. Start with a free pilot, prove it on your own pipeline.</p>
             <div class="flex flex-col sm:flex-row gap-4">
               <a href="#contact" class="bg-green-600 hover:bg-green-700 text-white px-6 py-3 text-base w-full sm:w-auto text-center rounded-lg">Revive My Leads →</a>
-              <a href="#about" class="border-2 border-green-600 text-green-600 hover:bg-green-50 px-6 py-3 text-base w-full sm:w-auto text-center rounded-lg">Try Ava Free →</a>
+              <a href="#about" class="bg-white border-2 border-green-600 text-green-600 hover:bg-green-50 px-6 py-3 text-base w-full sm:w-auto text-center rounded-lg">Try Ava Free →</a>
             </div>
           </div>
           <div class="relative">


### PR DESCRIPTION
## Summary
- add a white background class to the "Try Ava Free" hero CTA so it matches the original styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83de1a37c832b92df4e981291d92c