### PR TITLE
Add feature icons for hero section cards

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -216,21 +216,27 @@
         <div class="grid md:grid-cols-3 gap-8">
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487a9.706 9.706 0 0 1 3.188 2.323A9.68 9.68 0 0 1 21.75 12a9.708 9.708 0 0 1-2.322 6.363m-2.566 2.252a9.707 9.707 0 0 1-3.666 1.35 9.714 9.714 0 0 1-6.727-1.346A9.679 9.679 0 0 1 2.25 12c0-2.358.835-4.523 2.221-6.2M7.5 16.5 2.25 12M7.5 16.5v-3.75M7.5 16.5H3.75M16.5 7.5 21.75 12M16.5 7.5V3.75M16.5 7.5h3.75" />
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">Reactivate Cold Leads</h3>
               <p class="text-gray-600">Ava re-engages forgotten prospects with human-like conversations that spark replies.</p>
             </div>
           </div>
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25m10.5-2.25V5.25M3 8.25h18M4.5 7.5h15a1.5 1.5 0 0 1 1.5 1.5v9.75a1.5 1.5 0 0 1-1.5 1.5h-15a1.5 1.5 0 0 1-1.5-1.5V9a1.5 1.5 0 0 1 1.5-1.5Zm3.75 4.5h.008v.008H8.25V12Zm3.75 0h.008v.008H12V12Zm3.75 0h.008v.008h-.008V12Zm-7.5 3.75h.008v.008H8.25v-.008Zm3.75 0h.008v.008H12v-.008Zm3.75 0h.008v.008h-.008v-.008Z" />
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">Book Appointments Automatically</h3>
               <p class="text-gray-600">When leads respond, Ava schedules them straight onto your team's calendar.</p>
             </div>
           </div>
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 3.75c-1.19 0-2.338-.168-3.429-.48a12.078 12.078 0 0 1-2.872-1.32.75.75 0 0 0-.99.21A12.228 12.228 0 0 0 3.75 6.75c0 7.22 4.614 11.969 8.102 13.949a.75.75 0 0 0 .696 0c3.488-1.98 8.102-6.73 8.102-13.949a12.228 12.228 0 0 0-1.959-4.59.75.75 0 0 0-.99-.21 12.078 12.078 0 0 1-2.872 1.32 12.047 12.047 0 0 1-3.429.48Zm-1.5 8.25 2.25 2.25 3.75-3.75" />
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">No Risk, Results First</h3>
               <p class="text-gray-600">You don't pay until results are delivered. We prove value with a no-risk pilot program.</p>
             </div>


### PR DESCRIPTION
## Summary
- add inline SVG icons to the three feature cards on index2.html so each message has a representative graphic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c840948628832ba69835751ef070af