### PR TITLE
Add refresh icon to Reactivate Cold Leads card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -216,7 +216,16 @@
         <div class="grid md:grid-cols-3 gap-8">
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                   viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                   stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                   class="lucide lucide-refresh-cw h-12 w-12 text-green-600 mx-auto mb-4"
+                   aria-hidden="true">
+                <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"></path>
+                <path d="M21 3v5h-5"></path>
+                <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"></path>
+                <path d="M8 16H3v5"></path>
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">Reactivate Cold Leads</h3>
               <p class="text-gray-600">Ava re-engages forgotten prospects with human-like conversations that spark replies.</p>
             </div>


### PR DESCRIPTION
## Summary
- replace the placeholder SVG in the Reactivate Cold Leads card with the Lucide refresh icon

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c843a96750832b8e850a921a13f1b8