### PR TITLE
Restore calendar icon on How It Works card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -232,7 +232,24 @@
           </div>
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-calendar h-12 w-12 text-green-600 mx-auto mb-4"
+                aria-hidden="true"
+              >
+                <path d="M8 2v4"></path>
+                <path d="M16 2v4"></path>
+                <rect width="18" height="18" x="3" y="4" rx="2"></rect>
+                <path d="M3 10h18"></path>
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">Book Appointments Automatically</h3>
               <p class="text-gray-600">When leads respond, Ava schedules them straight onto your team's calendar.</p>
             </div>


### PR DESCRIPTION
## Summary
- replace the placeholder SVG in the Book Appointments Automatically card on index2.html with the original calendar icon

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8447d8364832bacab88a32452e46f