### PR TITLE
Add original shield icon to No Risk card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -256,7 +256,23 @@
           </div>
           <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
             <div class="p-8 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="lucide lucide-shield h-12 w-12 text-green-600 mx-auto mb-4"
+                aria-hidden="true"
+              >
+                <path
+                  d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+                ></path>
+              </svg>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">No Risk, Results First</h3>
               <p class="text-gray-600">You don't pay until results are delivered. We prove value with a no-risk pilot program.</p>
             </div>


### PR DESCRIPTION
## Summary
- restore the original Lucide shield SVG for the "No Risk, Results First" card in index2.html

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c844dc3ff4832bb642386bfdbe8861