### PR TITLE
Align About section cards with original styling

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -214,8 +214,8 @@
           <p class="text-xl text-gray-600 max-w-3xl mx-auto">Most sales teams close less than 20% of their leads — Ava reactivates the rest and puts booked sales calls on your calendar.</p>
         </div>
         <div class="grid md:grid-cols-3 gap-8">
-          <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
-            <div class="p-8 text-center">
+          <div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl py-6 shadow-sm border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div data-slot="card-content" class="p-8 text-center">
               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
                    viewBox="0 0 24 24" fill="none" stroke="currentColor"
                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -230,8 +230,8 @@
               <p class="text-gray-600">Ava re-engages forgotten prospects with human-like conversations that spark replies.</p>
             </div>
           </div>
-          <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
-            <div class="p-8 text-center">
+          <div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl py-6 shadow-sm border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div data-slot="card-content" class="p-8 text-center">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"
@@ -254,8 +254,8 @@
               <p class="text-gray-600">When leads respond, Ava schedules them straight onto your team's calendar.</p>
             </div>
           </div>
-          <div class="border-2 border-green-100 hover:border-green-300 transition-colors rounded-lg">
-            <div class="p-8 text-center">
+          <div data-slot="card" class="bg-card text-card-foreground flex flex-col gap-6 rounded-xl py-6 shadow-sm border-2 border-green-100 hover:border-green-300 transition-colors">
+            <div data-slot="card-content" class="p-8 text-center">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"


### PR DESCRIPTION
## Summary
- update the About section feature cards to use the original card wrapper styling for consistent borders and radii
- add data-slot attributes to match the original markup structure

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8482d3ec8832b8ad2ba6d444223b9