### PR TITLE
Style industry cards with bordered rounded layout

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -156,6 +156,20 @@
         flex-grow: 0 !important;
         box-sizing: border-box !important;
       }
+
+      .industry-card {
+        background-color: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 16px;
+        padding: 2rem;
+        text-align: center;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        transition: box-shadow 0.2s ease, transform 0.2s ease;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-white">
@@ -331,47 +345,35 @@
           <p class="text-xl text-gray-600 max-w-3xl mx-auto">Revive works best with businesses that rely on lead generation and sell relationship-based services.</p>
         </div>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">Insurance Agencies</h3>
-              <p class="text-gray-600">Re-engage prospects who didn't convert initially</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">Insurance Agencies</h3>
+            <p class="text-gray-600">Re-engage prospects who didn't convert initially</p>
           </div>
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">Real Estate Teams</h3>
-              <p class="text-gray-600">Turn cold leads into property viewings</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">Real Estate Teams</h3>
+            <p class="text-gray-600">Turn cold leads into property viewings</p>
           </div>
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">Medical & Dental</h3>
-              <p class="text-gray-600">Book consultations with interested patients</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">Medical & Dental</h3>
+            <p class="text-gray-600">Book consultations with interested patients</p>
           </div>
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">Home Services</h3>
-              <p class="text-gray-600">Convert estimates into scheduled services</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">Home Services</h3>
+            <p class="text-gray-600">Convert estimates into scheduled services</p>
           </div>
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">Coaches & Consultants</h3>
-              <p class="text-gray-600">Book discovery calls with potential clients</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">Coaches & Consultants</h3>
+            <p class="text-gray-600">Book discovery calls with potential clients</p>
           </div>
-          <div class="hover:shadow-lg transition-shadow">
-            <div class="p-6 text-center">
-              <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">High-Ticket eCommerce</h3>
-              <p class="text-gray-600">Schedule sales calls for premium products</p>
-            </div>
+          <div class="industry-card hover:shadow-lg transition-shadow">
+            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">High-Ticket eCommerce</h3>
+            <p class="text-gray-600">Schedule sales calls for premium products</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a reusable `industry-card` style that restores the rounded border, padding, and background
- update each industry card in the grid to use the new styling so the layout matches the original design

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c8538d5768832ba4d0f46719dba9f2