### PR TITLE
Restore building icon for Real Estate Teams card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -351,7 +351,7 @@
             <p class="text-gray-600">Re-engage prospects who didn't convert initially</p>
           </div>
           <div class="industry-card hover:shadow-lg transition-shadow">
-            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-building h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"><rect width="16" height="20" x="4" y="2" rx="2" ry="2"></rect><path d="M9 22v-4h6v4"></path><path d="M8 6h.01"></path><path d="M16 6h.01"></path><path d="M12 6h.01"></path><path d="M12 10h.01"></path><path d="M12 14h.01"></path><path d="M16 10h.01"></path><path d="M16 14h.01"></path><path d="M8 10h.01"></path><path d="M8 14h.01"></path></svg>
             <h3 class="text-lg font-semibold text-gray-900 mb-2">Real Estate Teams</h3>
             <p class="text-gray-600">Turn cold leads into property viewings</p>
           </div>


### PR DESCRIPTION
## Summary
- restore the Real Estate Teams industry card icon in index2.html using the original building SVG

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8578ef94c832baf9a156a30769cf5