### PR TITLE
Restore heart icon for Medical & Dental industry card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -356,7 +356,7 @@
             <p class="text-gray-600">Turn cold leads into property viewings</p>
           </div>
           <div class="industry-card hover:shadow-lg transition-shadow">
-            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"></path></svg>
             <h3 class="text-lg font-semibold text-gray-900 mb-2">Medical & Dental</h3>
             <p class="text-gray-600">Book consultations with interested patients</p>
           </div>


### PR DESCRIPTION
## Summary
- restore the lucide heart SVG in the Medical & Dental card within the industries section of index2.html.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c857c71ac0832bad358e05e1ef4ee9