### PR TITLE
Add shield icon to Coaches & Consultants industry card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -366,7 +366,21 @@
             <p class="text-gray-600">Convert estimates into scheduled services</p>
           </div>
           <div class="industry-card hover:shadow-lg transition-shadow">
-            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="lucide lucide-shield h-12 w-12 text-green-600 mx-auto mb-4"
+              aria-hidden="true"
+            >
+              <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"></path>
+            </svg>
             <h3 class="text-lg font-semibold text-gray-900 mb-2">Coaches & Consultants</h3>
             <p class="text-gray-600">Book discovery calls with potential clients</p>
           </div>


### PR DESCRIPTION
## Summary
- restore the shield lucide icon in the Coaches & Consultants industry card on index2.html

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c8582c4a0c832bba37d38236cdf273