### PR TITLE
Restore graduation cap icon for Coaches & Consultants card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -366,7 +366,7 @@
             <p class="text-gray-600">Convert estimates into scheduled services</p>
           </div>
           <div class="industry-card hover:shadow-lg transition-shadow">
-            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-graduation-cap h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"><path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"></path><path d="M22 10v6"></path><path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5"></path></svg>
             <h3 class="text-lg font-semibold text-gray-900 mb-2">Coaches & Consultants</h3>
             <p class="text-gray-600">Book discovery calls with potential clients</p>
           </div>


### PR DESCRIPTION
## Summary
- replace the shield icon in the Coaches & Consultants industry card with the intended lucide graduation cap SVG

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_e_68c8582c4a0c832bba37d38236cdf273