### PR TITLE
Restore people icon for High-Ticket eCommerce card

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -371,7 +371,7 @@
             <p class="text-gray-600">Book discovery calls with potential clients</p>
           </div>
           <div class="industry-card hover:shadow-lg transition-shadow">
-            <svg class="h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users h-12 w-12 text-green-600 mx-auto mb-4" aria-hidden="true"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path><path d="M16 3.128a4 4 0 0 1 0 7.744"></path><path d="M22 21v-2a4 4 0 0 0-3-3.87"></path><circle cx="9" cy="7" r="4"></circle></svg>
             <h3 class="text-lg font-semibold text-gray-900 mb-2">High-Ticket eCommerce</h3>
             <p class="text-gray-600">Schedule sales calls for premium products</p>
           </div>


### PR DESCRIPTION
## Summary
- replace the High-Ticket eCommerce card icon in index2.html with the lucide users graphic so the people symbol displays instead of the shield

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c85857ecb0832b96bf9efc9d236e7e