### PR TITLE
Refactor shared header and footer into reusable includes

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -1,0 +1,66 @@
+/* eslint-env browser */
+(function () {
+  'use strict';
+
+  const includes = [
+    { id: 'site-header', file: 'partials/header.html' },
+    { id: 'site-footer', file: 'partials/footer.html' }
+  ];
+
+  const getCandidateUrls = (file) => {
+    const urls = new Set();
+    const scriptEl = document.currentScript || document.querySelector('script[data-include-script]');
+
+    if (scriptEl && scriptEl.src) {
+      const scriptUrl = new URL(scriptEl.src, window.location.href);
+      const scriptBase = scriptUrl.href.replace(/assets\/js\/[^/?#]+(?:[?#].*)?$/, '');
+      urls.add(new URL(file, scriptBase).href);
+    }
+
+    const docBase = window.location.href.replace(/[^/]*([?#].*)?$/, '');
+    urls.add(new URL(file, docBase).href);
+    urls.add(new URL(file, window.location.origin + '/').href);
+    urls.add(file);
+    urls.add(`/${file.replace(/^\//, '')}`);
+
+    return Array.from(urls);
+  };
+
+  const loadPartial = async (id, file) => {
+    const container = document.getElementById(id);
+
+    if (!container) {
+      return;
+    }
+
+    const candidateUrls = getCandidateUrls(file);
+
+    for (const url of candidateUrls) {
+      try {
+        const response = await fetch(url);
+
+        if (response.ok) {
+          const markup = await response.text();
+          container.innerHTML = markup;
+          return;
+        }
+      } catch {
+        // Ignore fetch errors and try next candidate
+      }
+    }
+
+    console.warn(`Could not load include: ${file}`);
+  };
+
+  const loadIncludes = () => {
+    includes.forEach(({ id, file }) => {
+      void loadPartial(id, file);
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadIncludes);
+  } else {
+    loadIncludes();
+  }
+})();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,25 @@
+const js = require('@eslint/js');
+
+module.exports = [
+  {
+    ignores: ['node_modules/**']
+  },
+  js.configs.recommended,
+  {
+    files: ['assets/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+      globals: {
+        document: 'readonly',
+        window: 'readonly',
+        URL: 'readonly',
+        fetch: 'readonly',
+        console: 'readonly'
+      }
+    },
+    rules: {
+      'no-console': 'off'
+    }
+  }
+];

--- a/index.html
+++ b/index.html
@@ -176,23 +176,7 @@
     <div id="promotional-banner" onclick="document.getElementById('contact').scrollIntoView({ behavior: 'smooth', block: 'start' });">
       🚀 Up to 80% of your pipeline goes cold — Ava brings those leads back as booked sales calls fast! <b>Talk to Ava Now →</b>
     </div>
-  <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="flex justify-between items-center h-16">
-          <div class="flex items-center">
-            <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto" />
-          </div>
-          <nav class="hidden md:flex space-x-8">
-            <a href="/#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
-            <a href="/#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
-            <a href="/#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
-            <a href="/#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
-            <a href="mailto:info@revivesales.ai" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
-          </nav>
-          <a href="/#contact" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg get-started-btn">Get Started</a>
-        </div>
-      </div>
-    </header>
+  <div id="site-header"></div>
 
     <section class="relative bg-gradient-to-br from-green-50 to-white py-20 lg:py-32">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -466,39 +450,8 @@
       </div>
     </section>
 
-    <footer class="bg-gray-900 text-white py-12">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid md:grid-cols-4 gap-8">
-          <div>
-            <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto mb-4 filter brightness-0 invert" />
-            <p class="text-gray-400">Turn dead leads into booked sales calls with AI-powered conversations.</p>
-          </div>
-          <div>
-            <h3 class="text-lg font-semibold mb-4">Company</h3>
-            <ul class="space-y-2 text-gray-400">
-              <li><a href="/#about" class="hover:text-white transition-colors">About</a></li>
-              <li><a href="/#how-it-works" class="hover:text-white transition-colors">How It Works</a></li>
-              <li><a href="/#industries" class="hover:text-white transition-colors">Industries</a></li>
-              <li><a href="/#roadmap" class="hover:text-white transition-colors">Your Roadmap</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="text-lg font-semibold mb-4">Support</h3>
-            <ul class="space-y-2 text-gray-400">
-              <li><a href="mailto:info@revivesales.ai" class="hover:text-white transition-colors">Contact</a></li>
-              <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
-              <li><a href="terms-conditions.html" class="hover:text-white transition-colors">Terms &amp; Conditions</a></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="text-lg font-semibold mb-4">Contact</h3>
-            <a href="/#contact" class="text-gray-400 hover:text-white transition-colors">Ready to revive your leads?<br/>Get started today.</a>
-          </div>
-        </div>
-        <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-          <p>© 2025 RapidDev Solutions Inc. All rights reserved.</p>
-        </div>
-      </div>
-    </footer>
+    <div id="site-footer"></div>
+
+    <script src="assets/js/includes.js" data-include-script defer></script>
   </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,40 @@
+<!-- htmlhint doctype-first:false -->
+<footer class="bg-gray-900 text-white py-12">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="grid md:grid-cols-4 gap-8">
+      <div>
+        <a href="index.html" class="inline-flex">
+          <img src="assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto mb-4 filter brightness-0 invert" />
+        </a>
+        <p class="text-gray-400">Turn dead leads into booked sales calls with AI-powered conversations.</p>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold mb-4">Company</h3>
+        <ul class="space-y-2 text-gray-400">
+          <li><a href="index.html#about" class="hover:text-white transition-colors">About</a></li>
+          <li><a href="index.html#how-it-works" class="hover:text-white transition-colors">How It Works</a></li>
+          <li><a href="index.html#industries" class="hover:text-white transition-colors">Industries</a></li>
+          <li><a href="index.html#roadmap" class="hover:text-white transition-colors">Your Roadmap</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold mb-4">Support</h3>
+        <ul class="space-y-2 text-gray-400">
+          <li><a href="mailto:info@revivesales.ai" class="hover:text-white transition-colors">Contact</a></li>
+          <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
+          <li><a href="terms-conditions.html" class="hover:text-white transition-colors">Terms &amp; Conditions</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold mb-4">Contact</h3>
+        <a href="index.html#contact" class="text-gray-400 hover:text-white transition-colors">
+          Ready to revive your leads?<br />
+          Get started today.
+        </a>
+      </div>
+    </div>
+    <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
+      <p>© 2025 RapidDev Solutions Inc. All rights reserved.</p>
+    </div>
+  </div>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,20 @@
+<!-- htmlhint doctype-first:false -->
+<header class="bg-white border-b border-gray-200 sticky top-0 z-50">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex justify-between items-center h-16">
+      <div class="flex items-center">
+        <a href="index.html" class="flex items-center">
+          <img src="assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto" />
+        </a>
+      </div>
+      <nav class="hidden md:flex space-x-8">
+        <a href="index.html#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
+        <a href="index.html#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
+        <a href="index.html#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
+        <a href="index.html#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
+        <a href="mailto:info@revivesales.ai" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
+      </nav>
+      <a href="index.html#contact" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg get-started-btn">Get Started</a>
+    </div>
+  </div>
+</header>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -37,29 +37,7 @@
   <body>
     <div id="root">
       <!-- Header -->
-      <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="flex justify-between items-center h-16">
-            <div class="flex items-center">
-              <a href="index.html">
-                <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto">
-              </a>
-            </div>
-            <nav class="hidden md:flex space-x-8">
-              <a href="/#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
-              <a href="/#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
-              <a href="/#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
-              <a href="/#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
-              <a href="mailto:info@revivesales.ai" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
-            </nav>
-            <a href="/#contact">
-              <button class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-colors">
-                Get Started
-              </button>
-            </a>
-          </div>
-        </div>
-      </header>
+      <div id="site-header"></div>
 
       <!-- Main Content -->
       <main class="min-h-screen bg-white py-20">
@@ -126,46 +104,9 @@
       </main>
 
       <!-- Footer -->
-      <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="grid md:grid-cols-4 gap-8">
-            <div>
-              <a href="index.html">
-                <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto mb-4 filter brightness-0 invert">
-              </a>
-              <p class="text-gray-400">Turn dead leads into booked sales calls with AI-powered conversations.</p>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Company</h3>
-              <ul class="space-y-2 text-gray-400">
-                <li><a href="/#about" class="hover:text-white transition-colors">About</a></li>
-                <li><a href="/#how-it-works" class="hover:text-white transition-colors">How It Works</a></li>
-                <li><a href="/#industries" class="hover:text-white transition-colors">Industries</a></li>
-                <li><a href="/#roadmap" class="hover:text-white transition-colors">Your Roadmap</a></li>
-              </ul>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Support</h3>
-              <ul class="space-y-2 text-gray-400">
-                <li><a href="mailto:info@revivesales.ai" class="hover:text-white transition-colors">Contact</a></li>
-                <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
-                <li><a href="terms-conditions.html" class="hover:text-white transition-colors">Terms & Conditions</a></li>
-              </ul>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Contact</h3>
-              <a href="/#contact" class="text-gray-400 hover:text-white transition-colors">
-                Ready to revive your leads?<br>
-                Get started today.
-              </a>
-            </div>
-          </div>
-          <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-            <p>© 2025 RapidDev Solutions Inc. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <div id="site-footer"></div>
     </div>
+    <script src="assets/js/includes.js" data-include-script defer></script>
     <script src="https://link.msgsndr.com/js/form_embed.js"></script>
   </body>
 </html>

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ignoreFiles: ['node_modules/**', 'assets/index-BW-gzsfY.css'],
+  rules: {}
+};

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -37,29 +37,7 @@
   <body>
     <div id="root">
       <!-- Header -->
-      <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="flex justify-between items-center h-16">
-            <div class="flex items-center">
-              <a href="index.html">
-                <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto">
-              </a>
-            </div>
-            <nav class="hidden md:flex space-x-8">
-              <a href="/#about" class="text-gray-700 hover:text-green-600 transition-colors">About</a>
-              <a href="/#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
-              <a href="/#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
-              <a href="/#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
-              <a href="mailto:info@revivesales.ai" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
-            </nav>
-            <a href="/#contact">
-              <button class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-colors">
-                Get Started
-              </button>
-            </a>
-          </div>
-        </div>
-      </header>
+      <div id="site-header"></div>
 
       <!-- Main Content -->
       <main class="min-h-screen bg-white py-20">
@@ -135,46 +113,9 @@
       </main>
 
       <!-- Footer -->
-      <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="grid md:grid-cols-4 gap-8">
-            <div>
-              <a href="index.html">
-                <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-8 w-auto mb-4 filter brightness-0 invert">
-              </a>
-              <p class="text-gray-400">Turn dead leads into booked sales calls with AI-powered conversations.</p>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Company</h3>
-              <ul class="space-y-2 text-gray-400">
-                <li><a href="/#about" class="hover:text-white transition-colors">About</a></li>
-                <li><a href="/#how-it-works" class="hover:text-white transition-colors">How It Works</a></li>
-                <li><a href="/#industries" class="hover:text-white transition-colors">Industries</a></li>
-                <li><a href="/#roadmap" class="hover:text-white transition-colors">Your Roadmap</a></li>
-              </ul>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Support</h3>
-              <ul class="space-y-2 text-gray-400">
-                <li><a href="mailto:info@revivesales.ai" class="hover:text-white transition-colors">Contact</a></li>
-                <li><a href="privacy-policy.html" class="hover:text-white transition-colors">Privacy Policy</a></li>
-                <li><a href="terms-conditions.html" class="hover:text-white transition-colors">Terms & Conditions</a></li>
-              </ul>
-            </div>
-            <div>
-              <h3 class="text-lg font-semibold mb-4">Contact</h3>
-              <a href="/#contact" class="text-gray-400 hover:text-white transition-colors">
-                Ready to revive your leads?<br>
-                Get started today.
-              </a>
-            </div>
-          </div>
-          <div class="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
-            <p>© 2025 RapidDev Solutions Inc. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <div id="site-footer"></div>
     </div>
+    <script src="assets/js/includes.js" data-include-script defer></script>
     <script src="https://link.msgsndr.com/js/form_embed.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- extract the shared header and footer into partial fragments and add a client-side loader to fetch them
- swap duplicate markup in the main pages with header/footer placeholders populated by the loader
- add minimal ESLint and Stylelint configs to support the new script and keep linting passing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf55e60114832b94bb584b2ab85ed6