### PR TITLE
Update training form required fields and styling

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -57,7 +57,6 @@
             action="https://formsubmit.co/info@revivesales.ai"
             method="post"
             class="bg-white shadow-2xl shadow-gray-900/5 ring-1 ring-gray-200 rounded-3xl p-6 sm:p-10 space-y-10"
-            novalidate
           >
             <input type="hidden" name="_subject" value="Sales Agent Training Form Submission">
             <input type="hidden" name="_template" value="table">
@@ -69,32 +68,42 @@
             </div>
 
             <fieldset class="space-y-6">
-              <legend class="text-2xl font-semibold text-gray-900">Personal Information</legend>
+              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Personal Information</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div class="space-y-2">
-                  <label for="first-name" class="block text-sm font-semibold text-gray-900">First Name</label>
+                  <label for="first-name" class="block text-sm font-semibold text-gray-900">
+                    First Name <span class="text-red-500" aria-hidden="true">*</span><span class="sr-only"> required</span>
+                  </label>
                   <input
                     id="first-name"
                     name="First Name"
                     type="text"
                     maxlength="10000"
                     autocomplete="given-name"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0"
+                    required
+                    aria-required="true"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
                   >
                 </div>
                 <div class="space-y-2">
-                  <label for="last-name" class="block text-sm font-semibold text-gray-900">Last Name</label>
+                  <label for="last-name" class="block text-sm font-semibold text-gray-900">
+                    Last Name <span class="text-red-500" aria-hidden="true">*</span><span class="sr-only"> required</span>
+                  </label>
                   <input
                     id="last-name"
                     name="Last Name"
                     type="text"
                     maxlength="10000"
                     autocomplete="family-name"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0"
+                    required
+                    aria-required="true"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
                   >
                 </div>
                 <div class="space-y-2">
-                  <label for="phone" class="block text-sm font-semibold text-gray-900">Phone</label>
+                  <label for="phone" class="block text-sm font-semibold text-gray-900">
+                    Phone <span class="text-red-500" aria-hidden="true">*</span><span class="sr-only"> required</span>
+                  </label>
                   <input
                     id="phone"
                     name="Phone"
@@ -102,25 +111,31 @@
                     inputmode="tel"
                     maxlength="10000"
                     autocomplete="tel"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0"
+                    required
+                    aria-required="true"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
                   >
                 </div>
                 <div class="space-y-2">
-                  <label for="email" class="block text-sm font-semibold text-gray-900">Email</label>
+                  <label for="email" class="block text-sm font-semibold text-gray-900">
+                    Email <span class="text-red-500" aria-hidden="true">*</span><span class="sr-only"> required</span>
+                  </label>
                   <input
                     id="email"
                     name="Email"
                     type="email"
                     maxlength="10000"
                     autocomplete="email"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0"
+                    required
+                    aria-required="true"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
                   >
                 </div>
               </div>
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="text-2xl font-semibold text-gray-900">Company Identity &amp; Branding</legend>
+              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Company Identity &amp; Branding</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="business-name" class="block text-sm font-semibold text-gray-900">What is your business name?</label>
@@ -129,7 +144,7 @@
                     name="What is your business name?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -139,7 +154,7 @@
                     name="What is your company’s web address?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -149,7 +164,7 @@
                     name="How would you describe your business?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -159,7 +174,7 @@
                     name="What products or services do you offer?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -169,14 +184,14 @@
                     name="What makes your business or offer unique (top features, benefits, etc)?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
               </div>
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="text-2xl font-semibold text-gray-900">Knowledge Ava Should Have</legend>
+              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Knowledge Ava Should Have</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="special-offers" class="block text-sm font-semibold text-gray-900">Are there any special offers or promotions to mention?</label>
@@ -185,7 +200,7 @@
                     name="Are there any special offers or promotions to mention?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -195,7 +210,7 @@
                     name="List any questions or objections your human sales reps typically handle."
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -205,14 +220,14 @@
                     name="What questions should Ava ask to qualify the lead?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
               </div>
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="text-2xl font-semibold text-gray-900">Operational Details</legend>
+              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Operational Details</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="calendar-link" class="block text-sm font-semibold text-gray-900">What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?</label>
@@ -221,7 +236,7 @@
                     name="What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
                 <div class="space-y-2">
@@ -231,7 +246,7 @@
                     name="What geographic areas do you serve (if location-specific)?"
                     rows="4"
                     maxlength="10000"
-                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-0 resize-y"
+                    class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0 resize-y"
                   ></textarea>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- mark the contact fields on the demo AI training form as required and indicate that visually
- update form focus state colors to use the Revive green that matches the CTA styling
- enlarge the section legends and adjust spacing for clearer section separation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf5fa75d28832bb17ab32fc7439a7e