### PR TITLE
Use brand color for demo form legends

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -62,7 +62,7 @@
             <input type="hidden" name="_next" value="https://revivesales.ai/demo-ai-training-confirmation.html">
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Personal Information</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Personal Information</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div class="space-y-2">
                   <label for="first-name" class="block text-sm font-semibold text-gray-900">
@@ -129,7 +129,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Company Identity &amp; Branding</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Company Identity &amp; Branding</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="business-name" class="block text-sm font-semibold text-gray-900">What is your business name?</label>
@@ -185,7 +185,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Knowledge Ava Should Have</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Knowledge Ava Should Have</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="special-offers" class="block text-sm font-semibold text-gray-900">Are there any special offers or promotions to mention?</label>
@@ -221,7 +221,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-gray-900 tracking-tight mb-6">Operational Details</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Operational Details</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="calendar-link" class="block text-sm font-semibold text-gray-900">What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?</label>


### PR DESCRIPTION
## Summary
- update demo AI training form section legends to use the Revive brand green utility

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf6be70638832b849bd94d7acb70fe