### PR TITLE
Add spacing above secondary form sections

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -129,7 +129,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Company Identity &amp; Branding</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6 mt-8">Company Identity &amp; Branding</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="business-name" class="block text-sm font-semibold text-gray-900">What is your business name?</label>
@@ -185,7 +185,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Knowledge Ava Should Have</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6 mt-8">Knowledge Ava Should Have</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="special-offers" class="block text-sm font-semibold text-gray-900">Are there any special offers or promotions to mention?</label>
@@ -221,7 +221,7 @@
             </fieldset>
 
             <fieldset class="space-y-6">
-              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Operational Details</legend>
+              <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6 mt-8">Operational Details</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
                   <label for="calendar-link" class="block text-sm font-semibold text-gray-900">What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?</label>


### PR DESCRIPTION
## Summary
- add the supported `mt-8` top margin to the Company Identity & Branding, Knowledge Ava Should Have, and Operational Details fieldset legends to improve spacing between form sections
- keep the Personal Information legend unchanged to preserve the header alignment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf6c55b6b8832ba7d69b4d35f7f8bc