### PR TITLE
Format phone input on demo form

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -103,6 +103,7 @@
                     name="Phone"
                     type="tel"
                     inputmode="tel"
+                    pattern="\(\d{3}\)-\d{3}-\d{4}"
                     maxlength="10000"
                     autocomplete="tel"
                     required
@@ -263,5 +264,83 @@
     </div>
     <script src="assets/js/includes.js" data-include-script defer></script>
     <script src="https://link.msgsndr.com/js/form_embed.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const phoneInput = document.querySelector('#phone');
+        if (!phoneInput) {
+          return;
+        }
+
+        const formatPhoneNumber = (digits) => {
+          if (!digits) {
+            return '';
+          }
+
+          let formatted = '(' + digits.slice(0, Math.min(3, digits.length));
+
+          if (digits.length >= 3) {
+            formatted += ')';
+          }
+
+          if (digits.length > 3) {
+            formatted += '-' + digits.slice(3, Math.min(6, digits.length));
+          }
+
+          if (digits.length > 6) {
+            formatted += '-' + digits.slice(6, Math.min(10, digits.length));
+          }
+
+          return formatted;
+        };
+
+        const getCaretPosition = (formattedValue, digitsBeforeCaret) => {
+          if (digitsBeforeCaret <= 0) {
+            return 0;
+          }
+
+          let digitsSeen = 0;
+
+          for (let index = 0; index < formattedValue.length; index += 1) {
+            if (/\d/.test(formattedValue[index])) {
+              digitsSeen += 1;
+
+              if (digitsSeen === digitsBeforeCaret) {
+                return index + 1;
+              }
+            }
+          }
+
+          return formattedValue.length;
+        };
+
+        phoneInput.addEventListener('input', (event) => {
+          const target = event.target;
+          const rawValue = target.value;
+          const selectionStart = target.selectionStart ?? rawValue.length;
+          const digits = rawValue.replace(/\D/g, '').slice(0, 10);
+          const digitsBeforeCaret = Math.min(
+            rawValue.slice(0, selectionStart).replace(/\D/g, '').length,
+            digits.length
+          );
+          const formattedValue = formatPhoneNumber(digits);
+
+          target.value = formattedValue;
+
+          if (typeof target.setSelectionRange === 'function') {
+            const newCaretPosition = getCaretPosition(formattedValue, digitsBeforeCaret);
+            target.setSelectionRange(newCaretPosition, newCaretPosition);
+          }
+        });
+
+        const applyFinalFormat = () => {
+          const digits = phoneInput.value.replace(/\D/g, '').slice(0, 10);
+          phoneInput.value = formatPhoneNumber(digits);
+        };
+
+        phoneInput.addEventListener('blur', applyFinalFormat);
+
+        applyFinalFormat();
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a phone input pattern so browser validation matches the required mask
- format the phone field on input to enforce (###)-###-#### while keeping the caret in place
- normalize the value on blur so partial entries are cleaned up

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_e_68cf71901b64832ba33ee670ca84a126