### PR TITLE
Add placeholders to personal info inputs

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -74,6 +74,7 @@
                     type="text"
                     maxlength="10000"
                     autocomplete="given-name"
+                    placeholder="First Name"
                     required
                     aria-required="true"
                     class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
@@ -89,6 +90,7 @@
                     type="text"
                     maxlength="10000"
                     autocomplete="family-name"
+                    placeholder="Last Name"
                     required
                     aria-required="true"
                     class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
@@ -106,6 +108,7 @@
                     pattern="\(\d{3}\)-\d{3}-\d{4}"
                     maxlength="10000"
                     autocomplete="tel"
+                    placeholder="Phone"
                     required
                     aria-required="true"
                     class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"
@@ -121,6 +124,7 @@
                     type="email"
                     maxlength="10000"
                     autocomplete="email"
+                    placeholder="Email"
                     required
                     aria-required="true"
                     class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-400 focus:border-green-600 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-0"


### PR DESCRIPTION
## Summary
- add descriptive placeholders to the personal information inputs on the demo training form to mirror their labels

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_e_68cf731b53c8832bb93d380728e3d39a