### PR TITLE
Add optional markers to textarea labels

### DIFF
--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -137,7 +137,7 @@
               <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Company Identity &amp; Branding</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
-                  <label for="business-name" class="block text-sm font-semibold text-gray-900">What is your business name?</label>
+                  <label for="business-name" class="block text-sm font-semibold text-gray-900">What is your business name?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="business-name"
                     name="What is your business name?"
@@ -147,7 +147,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="web-address" class="block text-sm font-semibold text-gray-900">What is your company’s web address?</label>
+                  <label for="web-address" class="block text-sm font-semibold text-gray-900">What is your company’s web address?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="web-address"
                     name="What is your company’s web address?"
@@ -157,7 +157,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="business-description" class="block text-sm font-semibold text-gray-900">How would you describe your business?</label>
+                  <label for="business-description" class="block text-sm font-semibold text-gray-900">How would you describe your business?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="business-description"
                     name="How would you describe your business?"
@@ -167,7 +167,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="products-services" class="block text-sm font-semibold text-gray-900">What products or services do you offer?</label>
+                  <label for="products-services" class="block text-sm font-semibold text-gray-900">What products or services do you offer?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="products-services"
                     name="What products or services do you offer?"
@@ -177,7 +177,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="unique-offer" class="block text-sm font-semibold text-gray-900">What makes your business or offer unique (top features, benefits, etc)?</label>
+                  <label for="unique-offer" class="block text-sm font-semibold text-gray-900">What makes your business or offer unique (top features, benefits, etc)?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="unique-offer"
                     name="What makes your business or offer unique (top features, benefits, etc)?"
@@ -193,7 +193,7 @@
               <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Knowledge Ava Should Have</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
-                  <label for="special-offers" class="block text-sm font-semibold text-gray-900">Are there any special offers or promotions to mention?</label>
+                  <label for="special-offers" class="block text-sm font-semibold text-gray-900">Are there any special offers or promotions to mention?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="special-offers"
                     name="Are there any special offers or promotions to mention?"
@@ -203,7 +203,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="objections" class="block text-sm font-semibold text-gray-900">List any questions or objections your human sales reps typically handle.</label>
+                  <label for="objections" class="block text-sm font-semibold text-gray-900">List any questions or objections your human sales reps typically handle.<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="objections"
                     name="List any questions or objections your human sales reps typically handle."
@@ -213,7 +213,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="qualifying-questions" class="block text-sm font-semibold text-gray-900">What questions should Ava ask to qualify the lead?</label>
+                  <label for="qualifying-questions" class="block text-sm font-semibold text-gray-900">What questions should Ava ask to qualify the lead?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="qualifying-questions"
                     name="What questions should Ava ask to qualify the lead?"
@@ -229,7 +229,7 @@
               <legend class="block text-3xl font-bold text-green-600 tracking-tight mb-6">Operational Details</legend>
               <div class="space-y-6">
                 <div class="space-y-2">
-                  <label for="calendar-link" class="block text-sm font-semibold text-gray-900">What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?</label>
+                  <label for="calendar-link" class="block text-sm font-semibold text-gray-900">What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="calendar-link"
                     name="What calendar link should Ava use for booking sales calls (if you don’t have one, we can set one up for you)?"
@@ -239,7 +239,7 @@
                   ></textarea>
                 </div>
                 <div class="space-y-2">
-                  <label for="geographic-areas" class="block text-sm font-semibold text-gray-900">What geographic areas do you serve (if location-specific)?</label>
+                  <label for="geographic-areas" class="block text-sm font-semibold text-gray-900">What geographic areas do you serve (if location-specific)?<span class="text-sm font-normal text-gray-400"> (Optional)</span></label>
                   <textarea
                     id="geographic-areas"
                     name="What geographic areas do you serve (if location-specific)?"


### PR DESCRIPTION
## Summary
- add optional text indicator spans to every textarea label after the personal information section so optional questions are clearly marked

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf73b0bba4832ba3ec7c8a0cfac062