### PR TITLE
Load analytics from header include

### DIFF
--- a/assets/js/includes.js
+++ b/assets/js/includes.js
@@ -7,6 +7,121 @@
     { id: 'site-footer', file: 'partials/footer.html' }
   ];
 
+  const normalizePath = (path) => {
+    if (!path) {
+      return '';
+    }
+
+    let normalized = path.trim();
+
+    if (!normalized) {
+      return '';
+    }
+
+    if (!normalized.startsWith('/')) {
+      normalized = `/${normalized}`;
+    }
+
+    normalized = normalized.replace(/\/+$/, '');
+
+    if (!normalized) {
+      return '/';
+    }
+
+    return normalized.toLowerCase();
+  };
+
+  const parseSkipPaths = (value) => {
+    return value
+      .split(',')
+      .map(normalizePath)
+      .filter(Boolean);
+  };
+
+  const shouldSkipScript = (scriptEl, currentPath) => {
+    const skipAttr = scriptEl.getAttribute('data-skip-paths');
+
+    if (!skipAttr) {
+      return false;
+    }
+
+    const skipPaths = parseSkipPaths(skipAttr);
+
+    if (skipPaths.length === 0) {
+      return false;
+    }
+
+    return skipPaths.some((path) => {
+      if (path === '/') {
+        return currentPath === '/';
+      }
+
+      return currentPath === path || currentPath.endsWith(path);
+    });
+  };
+
+  const executeScripts = (container) => {
+    const scripts = container.querySelectorAll('script');
+    const currentPath = normalizePath(window.location.pathname || '/') || '/';
+
+    scripts.forEach((scriptEl) => {
+      if (scriptEl.dataset.includeProcessed === 'true') {
+        return;
+      }
+
+      if (shouldSkipScript(scriptEl, currentPath)) {
+        scriptEl.dataset.includeProcessed = 'true';
+        return;
+      }
+
+      const includeKey = scriptEl.dataset.includeKey;
+
+      if (includeKey) {
+        const existing = document.querySelector(
+          `script[data-include-origin="injected"][data-include-key="${includeKey}"]`
+        );
+
+        if (existing) {
+          scriptEl.dataset.includeProcessed = 'true';
+          return;
+        }
+      } else if (scriptEl.src) {
+        const src = scriptEl.src;
+        const existingWithSrc = Array.from(document.getElementsByTagName('script')).find(
+          (node) => node !== scriptEl && node.src === src
+        );
+
+        if (existingWithSrc) {
+          scriptEl.dataset.includeProcessed = 'true';
+          return;
+        }
+      }
+
+      const newScript = document.createElement('script');
+
+      Array.from(scriptEl.attributes).forEach(({ name, value }) => {
+        if (name === 'data-include-processed') {
+          return;
+        }
+
+        newScript.setAttribute(name, value);
+      });
+
+      newScript.dataset.includeOrigin = 'injected';
+
+      if (scriptEl.textContent) {
+        newScript.textContent = scriptEl.textContent;
+      }
+      document.head.appendChild(newScript);
+
+      scriptEl.dataset.includeProcessed = 'true';
+
+      if (scriptEl.parentNode) {
+        scriptEl.parentNode.removeChild(scriptEl);
+      }
+    });
+  };
+
   const getCandidateUrls = (file) => {
     const urls = new Set();
     const scriptEl = document.currentScript || document.querySelector('script[data-include-script]');
@@ -42,6 +157,7 @@
         if (response.ok) {
           const markup = await response.text();
           container.innerHTML = markup;
+          executeScripts(container);
           return;
         }
       } catch {

--- a/demo-ai-training-confirmation.html
+++ b/demo-ai-training-confirmation.html
@@ -18,23 +18,6 @@
     >
     <title>Sales Agent Training Form Submitted - Revive</title>
     <link rel="canonical" href="https://revivesales.ai/demo-ai-training-confirmation.html">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-61HEN1ZES8');
-    </script>
-    <!-- Microsoft Clarity -->
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "sbeu32u7zy");
-    </script>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
   <body>

--- a/demo-ai-training.html
+++ b/demo-ai-training.html
@@ -18,23 +18,6 @@
     >
     <title>Sales Agent Training Form - Revive</title>
     <link rel="canonical" href="https://revivesales.ai/demo-ai-training.html">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-61HEN1ZES8');
-    </script>
-    <!-- Microsoft Clarity -->
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "sbeu32u7zy");
-    </script>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
   <body>

--- a/index-backup.html
+++ b/index-backup.html
@@ -15,23 +15,6 @@
     <meta name="description" content="Turn wasted leads into revenue. Our AI Sales Agent re-engages cold prospects, books real sales calls automatically, and helps you close more without chasing.">
     <title>AI Sales Agent | Reactivate Cold Leads Into Booked Sales Calls | Revive</title>
     <link rel="canonical" href="https://revivesales.ai/">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-61HEN1ZES8');
-    </script>
-    <!-- Microsoft Clarity -->
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "sbeu32u7zy");
-    </script>
     <script type="module" crossorigin src="/assets/index-CF4YpnJ_.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
     <style>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,4 +1,27 @@
 <!-- htmlhint doctype-first:false -->
+<script
+  data-include-key="ga4-loader"
+  data-skip-paths="/demo-ai-training,/demo-ai-training.html,/demo-ai-training-confirmation,/demo-ai-training-confirmation.html"
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"
+></script>
+<script
+  data-include-key="ga4-config"
+  data-skip-paths="/demo-ai-training,/demo-ai-training.html,/demo-ai-training-confirmation,/demo-ai-training-confirmation.html"
+>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-61HEN1ZES8');
+</script>
+<script data-include-key="clarity">
+  (function(c,l,a,r,i,t,y){
+    c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+    t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+    y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+  })(window, document, "clarity", "script", "sbeu32u7zy");
+</script>
 <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex justify-between items-center h-16">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -15,23 +15,6 @@
     <meta name="description" content="Review how Revive collects, uses, and safeguards your data when you visit our site or use our services, and understand your privacy rights and choices.">
     <title>Privacy Policy - Revive</title>
     <link rel="canonical" href="https://revivesales.ai/privacy-policy.html">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-61HEN1ZES8');
-    </script>
-    <!-- Microsoft Clarity -->
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "sbeu32u7zy");
-    </script>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
   <body>

--- a/terms-conditions.html
+++ b/terms-conditions.html
@@ -15,23 +15,6 @@
     <meta name="description" content="Read the terms governing access to Revive's AI-driven sales services, including service use, client responsibilities, fees, and limitations of liability.">
     <title>Terms & Conditions - Revive</title>
     <link rel="canonical" href="https://revivesales.ai/terms-conditions.html">
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-61HEN1ZES8"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-61HEN1ZES8');
-    </script>
-    <!-- Microsoft Clarity -->
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "sbeu32u7zy");
-    </script>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- move the GA4 and Microsoft Clarity snippets into the shared header include so they load across the site while skipping GA4 on the demo form pages
- update the include loader to execute scripts pulled in with partials, de-duplicate them by key/src, normalize skip-path handling once per page, and clean up injected nodes after moving them to the head
- expand the GA4 skip list to cover both `.html` and extensionless routes for the training form and confirmation views

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf857a2978832b96a669df55034b73