### PR TITLE
Restyle profit calculator form

### DIFF
--- a/profit-calculator.html
+++ b/profit-calculator.html
@@ -21,19 +21,20 @@
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
     <style>
       .profit-calculator {
-        --profit-bg: #0f1222;
-        --profit-card: #161a32;
-        --profit-ink: #e9ecff;
-        --profit-muted: #a9b0d9;
-        --profit-accent: #6aa0ff;
-        --profit-accent-2: #9cf0d7;
-        --profit-danger: #ff7a7a;
-        --profit-ring: 0 0 0 2px rgba(106, 160, 255, 0.35), 0 12px 24px rgba(0, 0, 0, 0.28);
-        background: linear-gradient(180deg, #0b0e1b, #101433);
-        border-radius: 1.75rem;
-        padding: 2.5rem 2rem;
-        box-shadow: 0 25px 60px rgba(15, 18, 34, 0.45);
-        color: var(--profit-ink);
+        --pc-text: #0f172a;
+        --pc-muted: #64748b;
+        --pc-border: #e2e8f0;
+        --pc-card: #ffffff;
+        --pc-surface: #f8fafc;
+        --pc-accent: #16a34a;
+        --pc-accent-dark: #15803d;
+        --pc-negative: #dc2626;
+        color: var(--pc-text);
+        background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+        border-radius: 2rem;
+        padding: 3rem 2.5rem;
+        border: 1px solid rgba(226, 232, 240, 0.9);
+        box-shadow: 0 30px 80px rgba(15, 23, 42, 0.08);
       }
 
       .profit-calculator__inner {
@@ -41,71 +42,93 @@
         margin: 0 auto;
         display: flex;
         flex-direction: column;
-        gap: 2.25rem;
+        gap: 2.5rem;
       }
 
       .profit-calculator__lead {
-        color: var(--profit-muted);
+        color: var(--pc-muted);
         font-size: 1.05rem;
-        line-height: 1.6;
+        line-height: 1.65;
       }
 
       .profit-calculator__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: 1.75rem;
         grid-template-columns: repeat(12, minmax(0, 1fr));
       }
 
       .profit-calculator__card,
       .profit-calculator__out {
-        background: var(--profit-card);
-        border-radius: 0.9rem;
-        padding: 1.5rem;
-        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+        background: var(--pc-card);
+        border: 1px solid var(--pc-border);
+        border-radius: 1.5rem;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.06);
+        padding: 2rem;
       }
 
       .profit-calculator__card {
         grid-column: span 7;
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
       }
 
-      .profit-calculator__out {
-        grid-column: span 5;
+      .profit-calculator__section-title {
+        font: 700 1.35rem/1.2 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: var(--pc-text);
+      }
+
+      .profit-calculator__quick-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+
+      .profit-calculator__quick-label {
+        font: 600 0.95rem/1.1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: var(--pc-muted);
       }
 
       .profit-calculator__quick-actions {
         display: flex;
-        gap: 0.75rem;
         flex-wrap: wrap;
-        margin-bottom: 1rem;
+        gap: 0.75rem;
       }
 
       .profit-calculator__fields {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.9rem;
+        gap: 1.25rem;
       }
 
       .profit-calculator label {
         display: block;
-        color: var(--profit-muted);
-        font: 500 0.9rem/1.15 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: var(--pc-text);
+        font: 600 0.95rem/1.25 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         margin-bottom: 0.4rem;
+      }
+
+      .profit-calculator label span {
+        font-weight: 500;
+        font-size: 0.85rem;
+        color: var(--pc-muted);
       }
 
       .profit-calculator input {
         width: 100%;
-        padding: 0.75rem 0.75rem;
-        border-radius: 0.65rem;
-        border: 1px solid #232954;
-        background: #0e1230;
-        color: var(--profit-ink);
-        font: 600 1rem/1.1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        padding: 0.85rem 1rem;
+        border-radius: 0.9rem;
+        border: 1px solid var(--pc-border);
+        background: var(--pc-card);
+        color: var(--pc-text);
+        font: 500 1rem/1.1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
         outline: none;
       }
 
       .profit-calculator input:focus {
-        box-shadow: var(--profit-ring);
-        border-color: transparent;
+        border-color: var(--pc-accent);
+        box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.15);
       }
 
       .profit-calculator__actions {
@@ -113,77 +136,113 @@
         gap: 0.75rem;
         flex-wrap: wrap;
         align-items: center;
-        margin-top: 1.1rem;
       }
 
       .profit-calculator__button {
         cursor: pointer;
-        border: none;
-        border-radius: 0.65rem;
-        padding: 0.65rem 0.9rem;
-        background: #0e1437;
-        color: var(--profit-ink);
-        font: 600 0.9rem/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        transition: background 0.2s ease;
+        border-radius: 9999px;
+        border: 1px solid var(--pc-border);
+        background: var(--pc-card);
+        color: var(--pc-text);
+        font: 600 0.95rem/1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        padding: 0.6rem 1.1rem;
+        transition: all 0.2s ease;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
 
-      .profit-calculator__button:hover {
-        background: #0c1231;
+      .profit-calculator__button:hover,
+      .profit-calculator__button:focus-visible {
+        border-color: rgba(22, 163, 74, 0.5);
+        color: var(--pc-accent-dark);
+        box-shadow: 0 0 0 2px rgba(22, 163, 74, 0.12);
+      }
+
+      .profit-calculator__button:focus-visible {
+        outline: none;
       }
 
       .profit-calculator__button--accent {
-        background: var(--profit-accent);
-        color: #08122a;
+        border-color: transparent;
+        background: linear-gradient(135deg, var(--pc-accent), #22c55e);
+        color: #ffffff;
+        box-shadow: 0 15px 35px rgba(34, 197, 94, 0.25);
+      }
+
+      .profit-calculator__button--accent:hover,
+      .profit-calculator__button--accent:focus-visible {
+        background: linear-gradient(135deg, var(--pc-accent-dark), #16a34a);
+        color: #ffffff;
+        box-shadow: 0 18px 40px rgba(22, 163, 74, 0.3);
       }
 
       .profit-calculator__button--ghost {
-        border: 1px solid #273062;
+        background: var(--pc-surface);
       }
 
       .profit-calculator__muted {
-        color: var(--profit-muted);
-        font-size: 0.9rem;
+        color: var(--pc-muted);
+        font-size: 0.95rem;
+      }
+
+      .profit-calculator__out {
+        grid-column: span 5;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
       }
 
       .profit-calculator__stats {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.75rem;
-        margin-top: 0.75rem;
+        gap: 1.25rem;
       }
 
       .profit-calculator__tile {
-        background: #0e1230;
-        border: 1px solid #232954;
-        border-radius: 0.75rem;
-        padding: 0.9rem;
+        background: var(--pc-surface);
+        border: 1px solid var(--pc-border);
+        border-radius: 1rem;
+        padding: 1rem 1.1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
       }
 
       .profit-calculator__tile-key {
-        color: var(--profit-muted);
-        font: 600 0.8rem/1.1 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        color: var(--pc-muted);
+        font: 600 0.85rem/1.2 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
         text-transform: uppercase;
         letter-spacing: 0.04em;
       }
 
       .profit-calculator__tile-value {
-        color: var(--profit-ink);
-        font: 800 1.15rem/1.2 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-        margin-top: 0.35rem;
+        color: var(--pc-text);
+        font: 700 1.2rem/1.2 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       }
 
       .profit-calculator__tile-value--positive {
-        color: var(--profit-accent-2);
+        color: var(--pc-accent-dark);
       }
 
       .profit-calculator__tile-value--negative {
-        color: var(--profit-danger);
+        color: var(--pc-negative);
       }
 
       .profit-calculator__footnote {
-        margin-top: 0.75rem;
-        color: var(--profit-muted);
-        font-size: 0.8rem;
+        color: var(--pc-muted);
+        font-size: 0.85rem;
+        line-height: 1.5;
+      }
+
+      @media (max-width: 1100px) {
+        .profit-calculator {
+          padding: 2.5rem 1.75rem;
+        }
+
+        .profit-calculator__grid {
+          gap: 1.5rem;
+        }
       }
 
       @media (max-width: 980px) {
@@ -192,12 +251,30 @@
           grid-column: 1 / -1;
         }
 
-        .profit-calculator__fields {
-          grid-template-columns: 1fr;
-        }
-
+        .profit-calculator__fields,
         .profit-calculator__stats {
           grid-template-columns: 1fr;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .profit-calculator {
+          padding: 2rem 1.25rem;
+        }
+
+        .profit-calculator__card,
+        .profit-calculator__out {
+          padding: 1.5rem;
+          border-radius: 1.25rem;
+        }
+
+        .profit-calculator__actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .profit-calculator__button {
+          width: 100%;
         }
       }
     </style>
@@ -226,12 +303,17 @@
 
               <div class="profit-calculator__grid">
                 <section class="profit-calculator__card" aria-labelledby="profit-calculator-inputs">
-                  <h2 id="profit-calculator-inputs" class="sr-only">Profit calculator inputs</h2>
-                  <div class="profit-calculator__quick-actions">
-                    <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="2">Quick rate: 2%</button>
-                    <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="3">Quick rate: 3%</button>
-                    <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="5">Quick rate: 5%</button>
-                    <button id="reset" class="profit-calculator__button">Reset</button>
+                  <h2 id="profit-calculator-inputs" class="profit-calculator__section-title">Input assumptions</h2>
+                  <p class="profit-calculator__muted">Adjust the numbers below to mirror your database, conversions, and offer economics.</p>
+
+                  <div class="profit-calculator__quick-group" aria-label="Quick rate presets">
+                    <span class="profit-calculator__quick-label">Tap a quick rate to prefill appointment conversion:</span>
+                    <div class="profit-calculator__quick-actions">
+                      <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="2">Quick rate: 2%</button>
+                      <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="3">Quick rate: 3%</button>
+                      <button class="profit-calculator__button profit-calculator__button--ghost" data-rate="5">Quick rate: 5%</button>
+                      <button id="reset" class="profit-calculator__button">Reset</button>
+                    </div>
                   </div>
 
                   <div class="profit-calculator__fields" id="inputs">
@@ -268,7 +350,8 @@
                 </section>
 
                 <aside class="profit-calculator__out" aria-labelledby="profit-calculator-results">
-                  <h2 id="profit-calculator-results" class="sr-only">Profit calculator results</h2>
+                  <h2 id="profit-calculator-results" class="profit-calculator__section-title">Projected outcomes</h2>
+                  <p class="profit-calculator__muted">We update appointments, revenue, and ROI in real time as you make changes.</p>
                   <div class="profit-calculator__stats">
                     <div class="profit-calculator__tile">
                       <div class="profit-calculator__tile-key">Appointments</div>


### PR DESCRIPTION
## Summary
- restyle the profit calculator page with a light theme, rounded cards, and inputs that match the Sales Agent Training form styling
- add quick rate helper text and updated copy to clarify the form and live results panel
- refresh the results tiles with light surfaces, green positive states, and responsive spacing tweaks

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_e_68d4a2251b38832bafa2ecb83a866720