### PR TITLE
Fix Try Ava Free CTA link

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             <p class="text-xl text-gray-600 mb-8 leading-relaxed">Your leads aren't dead — they're just waiting. Ava, your AI sales agent, re-engages forgotten prospects and books qualified calls automatically. Start with a free pilot, prove it on your own pipeline.</p>
             <div class="flex flex-col sm:flex-row gap-4">
               <a href="/#contact" class="bg-green-600 hover:bg-green-700 text-white px-8 py-4 text-lg w-full sm:w-auto text-center rounded-lg">Revive My Leads →</a>
-              <a href="/#about" class="bg-white border-2 border-green-600 text-green-600 hover:bg-green-50 px-8 py-4 text-lg w-full sm:w-auto text-center rounded-lg">Try Ava Free →</a>
+              <a href="/#contact" class="bg-white border-2 border-green-600 text-green-600 hover:bg-green-50 px-8 py-4 text-lg w-full sm:w-auto text-center rounded-lg">Try Ava Free →</a>
             </div>
           </div>
           <div class="relative">


### PR DESCRIPTION
## Summary
- update the Try Ava Free call-to-action button to link to the contact section instead of the about section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d719b0d874832b9ccd867082320502