### PR TITLE
Add Profit Calculator navigation links and sitemap entry

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -15,6 +15,7 @@
           <li><a href="index.html#how-it-works" class="hover:text-white transition-colors">How It Works</a></li>
           <li><a href="index.html#industries" class="hover:text-white transition-colors">Industries</a></li>
           <li><a href="index.html#roadmap" class="hover:text-white transition-colors">Your Roadmap</a></li>
+          <li><a href="/profit-calculator.html" class="hover:text-white transition-colors">Profit Calculator</a></li>
         </ul>
       </div>
       <div>

--- a/partials/header.html
+++ b/partials/header.html
@@ -35,6 +35,7 @@
         <a href="index.html#how-it-works" class="text-gray-700 hover:text-green-600 transition-colors">How It Works</a>
         <a href="index.html#industries" class="text-gray-700 hover:text-green-600 transition-colors">Industries</a>
         <a href="index.html#roadmap" class="text-gray-700 hover:text-green-600 transition-colors">Your Roadmap</a>
+        <a href="/profit-calculator.html" class="text-gray-700 hover:text-green-600 transition-colors">Profit Calculator</a>
         <a href="mailto:info@revivesales.ai" class="text-gray-700 hover:text-green-600 transition-colors">Contact</a>
       </nav>
       <a href="index.html#contact" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg get-started-btn">Get Started</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>https://revivesales.ai/profit-calculator.html</loc>
+    <lastmod>2025-06-30T01:39:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add Profit Calculator link to the main navigation and footer menus
- register profit-calculator.html in the sitemap for search indexing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d804c8caac832ba8a6d94c1a0df859