### PR TITLE
Reduce spacing beneath profit calculator contact form

### DIFF
--- a/profit-calculator.html
+++ b/profit-calculator.html
@@ -342,7 +342,7 @@
       <div id="site-header"></div>
 
       <!-- Main Content -->
-      <main class="min-h-screen bg-white py-20">
+      <main class="min-h-screen bg-white pt-20 pb-0">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="text-center mb-12">
             <h1 class="text-4xl lg:text-5xl font-bold text-gray-900 mb-6">Revive Profit Calculator</h1>
@@ -428,7 +428,7 @@
           </section>
         </div>
 
-        <section id="contact" class="py-20 bg-gradient-to-br from-green-600 to-green-700">
+        <section id="contact" class="pt-20 pb-12 bg-gradient-to-br from-green-600 to-green-700">
           <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mb-12">
               <h2 class="text-3xl lg:text-5xl font-bold text-white mb-6">


### PR DESCRIPTION
## Summary
- trim extra bottom padding on the profit calculator layout to pull the footer closer to the form
- lower the contact section padding so the page ends with tighter spacing

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d807b92618832bba4037d69bcfbeaf