### PR TITLE
Update profit calculator revenue labels

### DIFF
--- a/profit-calculator.html
+++ b/profit-calculator.html
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Estimate appointments, enrollments, revenue, and ROI from your Revive campaigns with our interactive profit calculator."
+      content="Estimate appointments, closed sales, revenue, and ROI from your Revive campaigns with our interactive profit calculator."
     >
     <title>Revive Profit Calculator</title>
     <link rel="canonical" href="https://revivesales.ai/profit-calculator.html">
@@ -400,23 +400,19 @@
 
                 <aside class="profit-calculator__out" aria-labelledby="profit-calculator-results">
                   <h2 id="profit-calculator-results" class="profit-calculator__section-title">Projected Outcomes</h2>
-                  <p class="profit-calculator__muted">We update appointments, enrollments, and revenue in real time as you make changes.</p>
+                  <p class="profit-calculator__muted">We update appointments, closed sales, and revenue in real time as you make changes.</p>
                   <div class="profit-calculator__stats">
                     <div class="profit-calculator__tile">
                       <div class="profit-calculator__tile-key">Appointments</div>
                       <div id="outAppts" class="profit-calculator__tile-value">—</div>
                     </div>
                     <div class="profit-calculator__tile">
-                      <div class="profit-calculator__tile-key">Enrollments</div>
-                      <div id="outEnroll" class="profit-calculator__tile-value">—</div>
+                      <div class="profit-calculator__tile-key">Closed Sales</div>
+                      <div id="outClosed" class="profit-calculator__tile-value">—</div>
                     </div>
                     <div class="profit-calculator__tile">
-                      <div class="profit-calculator__tile-key">Gross Revenue</div>
-                      <div id="outGross" class="profit-calculator__tile-value">—</div>
-                    </div>
-                    <div class="profit-calculator__tile">
-                      <div class="profit-calculator__tile-key">Net Revenue</div>
-                      <div id="outNet" class="profit-calculator__tile-value profit-calculator__tile-value--positive">—</div>
+                      <div class="profit-calculator__tile-key">Revenue</div>
+                      <div id="outRevenue" class="profit-calculator__tile-value profit-calculator__tile-value--positive">—</div>
                     </div>
                   </div>
                   <p class="profit-calculator__footnote">
@@ -479,9 +475,8 @@
           closeRate: $('closeRate'),
           revPerCust: $('revPerCust'),
           outAppts: $('outAppts'),
-          outEnroll: $('outEnroll'),
-          outGross: $('outGross'),
-          outNet: $('outNet'),
+          outClosed: $('outClosed'),
+          outRevenue: $('outRevenue'),
           calc: $('calc'),
           reset: $('reset')
         };
@@ -498,16 +493,14 @@
           const revPer = val(els.revPerCust.value, 0);
 
           const appointments = Math.round(leads * apptPct);
-          const enrollments = Math.round(appointments * closePct);
-          const gross = enrollments * revPer;
-          const net = gross;
+          const closedSales = Math.round(appointments * closePct);
+          const revenue = closedSales * revPer;
 
           els.outAppts.textContent = nf.format(appointments);
-          els.outEnroll.textContent = nf.format(enrollments);
-          els.outGross.textContent = cf.format(gross);
-          els.outNet.textContent = cf.format(net);
-          els.outNet.classList.toggle('profit-calculator__tile-value--positive', net >= 0);
-          els.outNet.classList.toggle('profit-calculator__tile-value--negative', net < 0);
+          els.outClosed.textContent = nf.format(closedSales);
+          els.outRevenue.textContent = cf.format(revenue);
+          els.outRevenue.classList.toggle('profit-calculator__tile-value--positive', revenue >= 0);
+          els.outRevenue.classList.toggle('profit-calculator__tile-value--negative', revenue < 0);
         }
 
         document.querySelectorAll('[data-rate]').forEach((btn) => {


### PR DESCRIPTION
## Summary
- remove the gross revenue tile from the projected outcomes section
- rename enrollments to closed sales and net revenue to revenue across the calculator
- update supporting copy and calculations to use the new closed sales and revenue terminology

## Testing
- No automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d821997d74832b88e30f2c4de0b517