### PR TITLE
Add 10-day launch plan page

### DIFF
--- a/10-day-launch.html
+++ b/10-day-launch.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <link rel="icon" type="image/x-icon" href="favicon.ico?v=1750774954">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon.png?v=1750774954">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png?v=1750774954">
+    <link rel="apple-touch-icon" sizes="180x180" href="favicon.png?v=1750774954">
+    <link rel="shortcut icon" href="favicon.ico?v=1750774954">
+    <meta name="msapplication-TileImage" content="favicon.png?v=1750774954">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Follow our 10-day launch plan to go from kickoff call to conversions with a fully trained AI sales assistant."
+    >
+    <title>10-Day Launch Plan | Revive</title>
+    <link rel="canonical" href="https://revivesales.ai/10-day-launch.html">
+    <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
+  </head>
+  <body>
+    <div id="root">
+      <div id="site-header"></div>
+      <main class="bg-white">
+        <section class="pt-24 pb-16 bg-gray-50">
+          <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">10-Day Launch Plan</h1>
+            <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+              A fast-track path from kickoff to conversions.
+            </p>
+          </div>
+        </section>
+
+        <section class="py-20">
+          <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-16 items-start">
+              <div class="space-y-8">
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    1
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 1 – Kickoff Call</h2>
+                    <p class="text-gray-600">
+                      Align on goals, service focus, and confirm your target lead list.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    2
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 2 – Corporate &amp; Sales Info</h2>
+                    <p class="text-gray-600">
+                      You will share your business details for A2P approval (name, EIN, address, website, etc). Provide FAQs, pricing, sales notes, and booking links.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    3
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 3 – System Setup</h2>
+                    <p class="text-gray-600">
+                      We will build your CRM account and connect the integrations.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    4
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 4 – A2P Registration</h2>
+                    <p class="text-gray-600">
+                      We will submit compliance documents for your carrier approval.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    5
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 5 – AI Training</h2>
+                    <p class="text-gray-600">
+                      We will customize Ava with your services, FAQs, and tailored sales scripts.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    6
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 6 – Dry Run</h2>
+                    <p class="text-gray-600">
+                      We will run internal tests of AI flows, automations, and your booking links.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    7
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 7 – Final Demo</h2>
+                    <p class="text-gray-600">
+                      We will preview Ava in action for you, refine her tone, and fine-tune conversations.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    8
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 8 – Pilot Launch</h2>
+                    <p class="text-gray-600">
+                      We will activate your free pilot with up to 1,000 of your dead leads. Together we will track responses in real time.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    9
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 9 – Optimize</h2>
+                    <p class="text-gray-600">
+                      Together we will analyze conversations, measure conversions, and adjust flows.
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                    10
+                  </div>
+                  <div>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 10 – Sign-Up &amp; Scale</h2>
+                    <p class="text-gray-600">
+                      Finally, we will move into full pay-for-performance and give you the option to expand into new incoming leads.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <aside class="bg-green-50 border border-green-100 rounded-3xl p-8 shadow-lg">
+                <h3 class="text-3xl font-bold text-green-800 mb-4">Where you'll be in 10 days</h3>
+                <p class="text-lg text-green-900 mb-6">
+                  By the end of this sprint, you'll have a fully trained AI sales agent ready to revive dormant leads, book meetings, and help your team close more deals.
+                </p>
+                <ul class="space-y-4 text-green-900">
+                  <li class="flex items-start space-x-3">
+                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
+                    <span>CRM and automations tailored to your workflow</span>
+                  </li>
+                  <li class="flex items-start space-x-3">
+                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
+                    <span>Carrier-approved messaging ready to deploy</span>
+                  </li>
+                  <li class="flex items-start space-x-3">
+                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
+                    <span>Real-time monitoring and optimization support</span>
+                  </li>
+                </ul>
+              </aside>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <div id="site-footer"></div>
+    </div>
+
+    <script src="assets/js/includes.js" data-include-script defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated 10-day launch plan landing page with header/footer includes
- style the daily milestones to mirror the roadmap section treatment and add a supporting results summary panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8225b4908832b83c8df94fd81058f