### PR TITLE
Remove 10-day launch sidebar summary

### DIFF
--- a/10-day-launch.html
+++ b/10-day-launch.html
@@ -148,26 +148,6 @@
                   </div>
                 </div>
               </div>
-              <aside class="bg-green-50 border border-green-100 rounded-3xl p-8 shadow-lg">
-                <h3 class="text-3xl font-bold text-green-800 mb-4">Where you'll be in 10 days</h3>
-                <p class="text-lg text-green-900 mb-6">
-                  By the end of this sprint, you'll have a fully trained AI sales agent ready to revive dormant leads, book meetings, and help your team close more deals.
-                </p>
-                <ul class="space-y-4 text-green-900">
-                  <li class="flex items-start space-x-3">
-                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
-                    <span>CRM and automations tailored to your workflow</span>
-                  </li>
-                  <li class="flex items-start space-x-3">
-                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
-                    <span>Carrier-approved messaging ready to deploy</span>
-                  </li>
-                  <li class="flex items-start space-x-3">
-                    <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-green-600 text-white text-sm font-semibold">✓</span>
-                    <span>Real-time monitoring and optimization support</span>
-                  </li>
-                </ul>
-              </aside>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- remove the "Where you'll be in 10 days" sidebar content from the 10-day launch page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8238dfccc832b8a38c0379145a3f4