### PR TITLE
Update launch plan content

### DIFF
--- a/10-day-launch.html
+++ b/10-day-launch.html
@@ -14,9 +14,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Follow our 10-day launch plan to go from kickoff call to conversions with a fully trained AI sales assistant."
+      content="Follow our 8-day launch plan to go from initial demo to conversions with a fully trained AI sales assistant."
     >
-    <title>10-Day Launch Plan | Revive</title>
+    <title>8-Day Launch Plan | Revive</title>
     <link rel="canonical" href="https://revivesales.ai/10-day-launch.html">
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
@@ -26,7 +26,7 @@
       <main class="bg-white">
         <section class="pt-24 pb-16 bg-gray-50">
           <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">10-Day Launch Plan</h1>
+            <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">8-Day Launch Plan</h1>
             <p class="text-xl text-gray-600 max-w-3xl mx-auto">
               A fast-track path from kickoff to conversions.
             </p>
@@ -42,7 +42,7 @@
                     1
                   </div>
                   <div>
-                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 1 – Kickoff Call</h2>
+                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 1 – Initial Demo</h2>
                     <p class="text-gray-600">
                       Align on goals, service focus, and confirm your target lead list.
                     </p>
@@ -122,28 +122,6 @@
                     <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 8 – Pilot Launch</h2>
                     <p class="text-gray-600">
                       We will activate your free pilot with up to 1,000 of your dead leads. Together we will track responses in real time.
-                    </p>
-                  </div>
-                </div>
-                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
-                    9
-                  </div>
-                  <div>
-                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 9 – Optimize</h2>
-                    <p class="text-gray-600">
-                      Together we will analyze conversations, measure conversions, and adjust flows.
-                    </p>
-                  </div>
-                </div>
-                <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
-                    10
-                  </div>
-                  <div>
-                    <h2 class="text-2xl font-semibold text-gray-900 mb-2">Day 10 – Sign-Up &amp; Scale</h2>
-                    <p class="text-gray-600">
-                      Finally, we will move into full pay-for-performance and give you the option to expand into new incoming leads.
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- update the launch plan page copy to reflect an 8-day plan and initial demo kickoff
- remove the final two day cards so the page stops at day 8

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d824887664832bb09c5ab57595e8c0