### PR TITLE
Align homepage header height with other pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@
       [class*="Header"],
       [class*="nav"],
       [class*="Nav"] {
-        min-height: 60px !important;
-        padding-top: 0.75rem !important;
-        padding-bottom: 0.75rem !important;
+        min-height: 4rem !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
         transition: none !important;
       }
 
@@ -42,10 +42,10 @@
       [class*="Header"].sticky,
       [class*="nav"].sticky,
       [class*="Nav"].sticky {
-        min-height: 60px !important;
+        min-height: 4rem !important;
         height: auto !important;
-        padding-top: 0.75rem !important;
-        padding-bottom: 0.75rem !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
         padding-left: 1rem !important;
         padding-right: 1rem !important;
         transform: none !important;


### PR DESCRIPTION
## Summary
- adjust the homepage header and sticky overrides so the banner uses the same 4rem height as other pages
- keep the promotional banner spacing while removing extra vertical padding that caused the taller header

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d826226b60832bb01273dd0223abda