### PR TITLE
Adjust hero background on launch page

### DIFF
--- a/10-day-launch.html
+++ b/10-day-launch.html
@@ -24,7 +24,7 @@
     <div id="root">
       <div id="site-header"></div>
       <main class="bg-white">
-        <section class="pt-24 pb-16 bg-gray-50">
+        <section class="pt-24 pb-16 bg-white">
           <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">8-Day Launch Plan</h1>
             <p class="text-xl text-gray-600 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- update the hero section on the 10-day launch page to use a white background so it matches the surrounding layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d827ea80cc832ba70682bb73f45c22