### PR TITLE
Rename launch plan page to 8-day variant

### DIFF
--- a/8-day-launch.html
+++ b/8-day-launch.html
@@ -17,7 +17,7 @@
       content="Follow our 8-day launch plan to go from initial demo to conversions with a fully trained AI sales assistant."
     >
     <title>8-Day Launch Plan | Revive</title>
-    <link rel="canonical" href="https://revivesales.ai/10-day-launch.html">
+    <link rel="canonical" href="https://revivesales.ai/8-day-launch.html">
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- rename the launch plan landing page from 10-day to 8-day
- update the canonical link to reflect the new page path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d828a0ddbc832b80e81e2bb498dfc6