### PR TITLE
Disallow 8-day launch page in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -22,3 +22,6 @@ Disallow: /partials/footer.html
 Disallow: /demo-ai-training.html
 Disallow: /demo-ai-training-confirmation.html
 
+# Disallow crawling of launch campaign pages
+Disallow: /8-day-launch.html
+


### PR DESCRIPTION
## Summary
- prevent search engines from indexing the 8-day launch landing page by adding a disallow rule to robots.txt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8292e21dc832b9bfff82224ba46c7