### PR TITLE
Increase hero padding on 8-day launch page

### DIFF
--- a/8-day-launch.html
+++ b/8-day-launch.html
@@ -24,7 +24,7 @@
     <div id="root">
       <div id="site-header"></div>
       <main class="bg-white">
-        <section class="pt-24 pb-16 bg-white">
+        <section class="pt-32 pb-16 bg-white">
           <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">8-Day Launch Plan</h1>
             <p class="text-xl text-gray-600 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- increase top padding on the hero section of the 8-day launch page to add space above the title

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d829594df8832b8e0bae6ecaf0b378