### PR TITLE
Adjust robots.txt index backup section

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -12,6 +12,8 @@ Disallow: /*.json$
 # Disallow crawling of legal pages
 Disallow: /privacy-policy.html
 Disallow: /terms-conditions.html
+
+# Disallow crawling of backup index page
 Disallow: /index-backup.html
 
 # Disallow crawling of partial templates


### PR DESCRIPTION
## Summary
- move the index backup disallow rule into its own section in robots.txt

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d829aa442c832b92ae8dac45062e21