### PR TITLE
Add custom hero padding to 8-day launch page

### DIFF
--- a/8-day-launch.html
+++ b/8-day-launch.html
@@ -19,12 +19,23 @@
     <title>8-Day Launch Plan | Revive</title>
     <link rel="canonical" href="https://revivesales.ai/8-day-launch.html">
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css">
+    <style>
+      .launch-hero {
+        padding-top: 6rem;
+      }
+
+      @media (min-width: 1024px) {
+        .launch-hero {
+          padding-top: 8rem;
+        }
+      }
+    </style>
   </head>
   <body>
     <div id="root">
       <div id="site-header"></div>
       <main class="bg-white">
-        <section class="pt-24 pb-16 bg-white">
+        <section class="launch-hero pb-16 bg-white">
           <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h1 class="text-4xl lg:text-6xl font-bold text-gray-900 mb-6">8-Day Launch Plan</h1>
             <p class="text-xl text-gray-600 max-w-3xl mx-auto">


### PR DESCRIPTION
## Summary
- add page-specific CSS to create additional hero padding on the 8-day launch page
- wire the hero section to the new class so the spacing appears immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d829594df8832b8e0bae6ecaf0b378