### PR TITLE
Adjust desktop hero padding on launch page

### DIFF
--- a/8-day-launch.html
+++ b/8-day-launch.html
@@ -26,7 +26,7 @@
 
       @media (min-width: 1024px) {
         .launch-hero {
-          padding-top: 8rem;
+          padding-top: 6rem;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- reduce the hero section's desktop padding on the 8-day launch page to tighten spacing

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d82ba2e1e0832bbb8cf5e9f3e3c6a8