### PR TITLE
Fix mobile layout of 8-Day Launch step badges

### DIFF
--- a/8-day-launch.html
+++ b/8-day-launch.html
@@ -49,7 +49,7 @@
             <div class="grid lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] gap-16 items-start">
               <div class="space-y-8">
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     1
                   </div>
                   <div>
@@ -60,7 +60,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     2
                   </div>
                   <div>
@@ -71,7 +71,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     3
                   </div>
                   <div>
@@ -82,7 +82,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     4
                   </div>
                   <div>
@@ -93,7 +93,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     5
                   </div>
                   <div>
@@ -104,7 +104,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     6
                   </div>
                   <div>
@@ -115,7 +115,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     7
                   </div>
                   <div>
@@ -126,7 +126,7 @@
                   </div>
                 </div>
                 <div class="flex items-start space-x-4 bg-gray-50 rounded-2xl p-6 shadow-sm">
-                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg">
+                  <div class="bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center font-bold text-lg shrink-0">
                     8
                   </div>
                   <div>


### PR DESCRIPTION
## Summary
- prevent the numbered badges in the 8-Day Launch list from shrinking on small screens by adding a flex shrink override

## Testing
- npm run lint:html

------
https://chatgpt.com/codex/tasks/task_e_68d82c8ab910832baf128c5bba92b8a2