### PR TITLE
Fix Tar Heel demo video sizing and preview

### DIFF
--- a/demo-tar-heel-insurance-agency.html
+++ b/demo-tar-heel-insurance-agency.html
@@ -172,11 +172,11 @@
           </div>
 
           <div class="max-w-4xl mx-auto mb-16">
-            <div class="relative w-full overflow-hidden rounded-2xl shadow-2xl bg-black" style="padding-top: 56.25%;">
+            <div class="w-full shadow-2xl bg-black">
               <video
                 controls
-                preload="metadata"
-                class="absolute inset-0 h-full w-full object-cover"
+                preload="auto"
+                class="block w-full h-auto"
               >
                 <source src="assets/demo-tar-heel-insurance-agency.mp4" type="video/mp4" />
                 Your browser does not support the video tag.


### PR DESCRIPTION
## Summary
- remove the aspect-ratio wrapper so the player matches the video dimensions and square edges
- let the video element size itself with block display and auto height while keeping the drop shadow
- switch the video to preload automatically so the first frame shows as a preview

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e14f47d6e4832b986ea9a33832df4c