### PR TITLE
Replace shield icon and update feature card copy in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,15 +264,14 @@
                 stroke-width="2"
                 stroke-linecap="round"
                 stroke-linejoin="round"
-                class="lucide lucide-shield h-12 w-12 text-green-600 mx-auto mb-4"
+                class="lucide lucide-chart-growth h-12 w-12 text-green-600 mx-auto mb-4"
                 aria-hidden="true"
               >
-                <path
-                  d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
-                ></path>
+                <path d="M6 4v14h14"></path>
+                <path d="M7 14Q15 14 15 6"></path>
               </svg>
-              <h3 class="text-xl font-semibold text-gray-900 mb-3">No Risk, Results First</h3>
-              <p class="text-gray-600">You don't pay until results are delivered. We prove value with a no-risk pilot program.</p>
+              <h3 class="text-xl font-semibold text-gray-900 mb-3">Scale Without More Staff</h3>
+              <p class="text-gray-600">Turn more leads into conversations and appointments without chasing old leads.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Replace the shield icon and the "No Risk, Results First" messaging with a growth-chart icon and stronger scaling-focused copy to better represent the feature of converting dormant leads without adding staff.

### Description
- In `index.html` updated the feature card by changing the SVG `class` from `lucide-shield` to `lucide-chart-growth`, replacing the shield SVG path with growth-chart paths, and updating the heading and paragraph to "Scale Without More Staff" and "Turn more leads into conversations and appointments without chasing old leads." 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04814998c832791182939e14800b6)