### PR TITLE
Update roadmap messaging in "Your Roadmap to Booked Calls" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,22 +411,22 @@
             <div class="flex items-start space-x-4">
               <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">3</div>
               <div>
-                <h3 class="text-xl font-semibold text-gray-900 mb-2">Free Pilot</h3>
-                <p class="text-gray-600">Ava re-engages up to 1,000 of your cold leads for free and books calls straight to your calendar.</p>
+                <h3 class="text-xl font-semibold text-gray-900 mb-2">Start a Pilot</h3>
+                <p class="text-gray-600">We'll start a campaign to re-engage your old leads and books calls straight to your calendar.</p>
               </div>
             </div>
             <div class="flex items-start space-x-4">
               <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">4</div>
               <div>
                 <h3 class="text-xl font-semibold text-gray-900 mb-2">Scale on Results</h3>
-                <p class="text-gray-600">Love the results? Scale effortlessly with our pay-for-performance model.</p>
+                <p class="text-gray-600">Love the results? Ava scales effortlessly to contact thousands of leads a day.</p>
               </div>
             </div>
             <div class="flex items-start space-x-4">
               <div class="bg-green-600 text-white rounded-full w-8 h-8 flex items-center justify-center font-bold">5</div>
               <div>
                 <h3 class="text-xl font-semibold text-gray-900 mb-2">Expand to New Leads</h3>
-                <p class="text-gray-600">After we re-engage your old leads, Ava also qualifies and books your new incoming leads.</p>
+                <p class="text-gray-600">After you see the results from re-engaging your old leads, we can launch campaigns for Ava to qualify and book your new incoming leads from Google and Meta ads.</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Update and clarify the roadmap copy to better describe the pilot offer and how Ava scales to new leads.
- These are content-only adjustments limited to the "Your Roadmap to Booked Calls" section to improve messaging and user understanding.

### Description
- Changed the step 3 heading from `Free Pilot` to `Start a Pilot` in `index.html`.
- Replaced the step 3 description with `We'll start a campaign to re-engage your old leads and books calls straight to your calendar.` in `index.html`.
- Replaced the step 4 description with `Love the results? Ava scales effortlessly to contact thousands of leads a day.` and the step 5 description with `After you see the results from re-engaging your old leads, we can launch campaigns for Ava to qualify and book your new incoming leads from Google and Meta ads.` in `index.html`.

### Testing
- Verified the new strings are present with `rg -n` against `index.html` and inspected the updated lines with `nl -ba`; the searches returned the expected updated text.
- No automated unit tests were necessary since this is a copy-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c053d72e148327b4d4051bad983010)