### PR TITLE
Add Facebook domain verification meta tag to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="favicon.png?v=1750774954">
     <link rel="shortcut icon" href="favicon.ico?v=1750774954">
     <meta name="msapplication-TileImage" content="favicon.png?v=1750774954">
+    <meta name="facebook-domain-verification" content="zoy2lbwuuqu8zdx1hwkst5oi3be696" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Turn wasted leads into revenue. Our AI Sales Agent re-engages cold prospects, books real sales calls automatically, and helps you close more without chasing.">
     <title>AI Sales Agent | Reactivate Cold Leads Into Booked Sales Calls | Revive</title>


### PR DESCRIPTION
### Motivation
- Add Facebook domain verification metadata so Facebook can verify ownership of the Revive site.

### Description
- Inserted the meta tag ``<meta name="facebook-domain-verification" content="zoy2lbwuuqu8zdx1hwkst5oi3be696" />`` into the `<head>` of `index.html`.

### Testing
- Confirmed the tag is present by inspecting `index.html` (viewed the head lines); no automated runtime tests were required for this static metadata change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51144a77c8327b3d47fc65119e30f)