### PR TITLE
Remove shared header/footer from costmetic-surgeons landing page

### DIFF
--- a/costmetic-surgeons.html
+++ b/costmetic-surgeons.html
@@ -14,8 +14,7 @@
     </style>
   </head>
   <body class="bg-white text-gray-900">
-    <div id="site-header"></div>
-    <main class="pt-24 pb-20">
+    <main class="py-20">
       <div class="max-w-4xl mx-auto px-4">
         <article class="longform prose prose-lg max-w-none">
           <h1>Aesthetic and Surgical Healthcare Providers:</h1>
@@ -76,17 +75,5 @@
         </article>
       </div>
     </main>
-    <div id="site-footer"></div>
-    <script>
-      async function loadPartial(id, path) {
-        const target = document.getElementById(id);
-        if (!target) return;
-        const response = await fetch(path);
-        if (!response.ok) return;
-        target.innerHTML = await response.text();
-      }
-      loadPartial('site-header', '/partials/header.html');
-      loadPartial('site-footer', '/partials/footer.html');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make `costmetic-surgeons.html` a standalone landing page without the site-wide header/footer chrome so it can be used as an isolated landing experience.

### Description
- Removed the `div id="site-header"` and `div id="site-footer"` placeholders and deleted the partial-loading script that called `loadPartial` for header/footer in `costmetic-surgeons.html`.
- Replaced the page-level container padding from `pt-24 pb-20` to `py-20` to preserve balanced vertical spacing after removing the fixed header dependency.

### Testing
- Verified via `rg -n "site-header|site-footer|loadPartial|<main class" costmetic-surgeons.html` that no header/footer placeholders or partial-loading calls remain, and the `main` class is updated; the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f1bad8a4832b91bac57c3e810470)