### PR TITLE
Tighten vertical spacing and adjust hero layout in cosmetic-surgeons.html

### DIFF
--- a/cosmetic-surgeons.html
+++ b/cosmetic-surgeons.html
@@ -70,31 +70,31 @@ src="https://www.facebook.com/tr?id=1619414729205128&ev=PageView&noscript=1"
     </style>
   </head>
   <body class="text-gray-900">
-    <header class="logo-bar py-10 md:py-12 px-4">
+    <header class="logo-bar py-8 md:py-10 px-4">
       <div class="hero-wrap flex items-center justify-center">
         <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-16 md:h-20 w-auto" />
       </div>
     </header>
 
-    <main class="py-14 md:py-20 px-4">
+    <main class="pt-8 md:pt-10 pb-14 md:pb-20 px-4">
       <section class="hero-wrap">
         <h1 class="text-center text-3xl md:text-5xl font-bold text-slate-900 leading-tight">
           Aesthetic and Surgical Healthcare Providers:
         </h1>
-        <h2 class="text-center text-3xl md:text-5xl font-bold text-slate-900 mt-6 md:mt-8 leading-tight">
+        <h2 class="text-center text-3xl md:text-5xl font-bold text-slate-900 mt-4 md:mt-5 leading-tight">
           We Guarantee <span class="text-green-600">30 New Patients</span> OR YOU DON'T PAY
         </h2>
 
-        <div class="mt-12 md:mt-16 video-shell">
+        <div class="mt-8 md:mt-10 video-shell">
           <div id="vidalytics_embed_HPGdKzkCWCw6QUNF" style="width: 100%; position: relative; padding-top: 56.25%"></div>
         </div>
 
-        <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <div class="mt-6 md:mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
           <a class="cta cta-primary w-full sm:w-auto" href="https://sales.revivesales.ai/book-call">Book a Strategy Call</a>
           <a class="cta bg-white border border-gray-300 w-full sm:w-auto" href="https://sales.revivesales.ai/book-call">Claim Your 30-Patient Guarantee</a>
         </div>
 
-        <article class="mt-12 bg-white border border-gray-200 rounded-2xl p-6 md:p-10 prose prose-lg max-w-none">
+        <article class="mt-8 md:mt-10 bg-white border border-gray-200 rounded-2xl p-6 md:p-10 prose prose-lg max-w-none">
           <h3>How This Works</h3>
           <p>
             Most aesthetic practices don’t actually have a lead generation problem. They have a follow-up capacity


### PR DESCRIPTION
### Motivation

- Reduce excessive vertical spacing and improve visual balance of the hero and content blocks across viewports.

### Description

- Reduced header padding by changing `py-10 md:py-12` to `py-8 md:py-10` to tighten the logo bar.
- Converted `main` vertical padding to explicit `pt`/`pb` (`py-14 md:py-20` -> `pt-8 md:pt-10 pb-14 md:pb-20`) to better control top spacing.
- Lowered top margins for the subtitle, video container, CTA group, and article (`mt-6/12/10/12` -> `mt-4/8/6/8` with corresponding `md:` adjustments) to compact the hero area.

### Testing

- No automated tests were added or run for this cosmetic HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41228db60832bb0de024dfe1f9ef8)