### PR TITLE
Lazy-load Vidalytics embed, add preconnect/dns-prefetch, and refine hero/article layout

### DIFF
--- a/cosmetic-surgeons.html
+++ b/cosmetic-surgeons.html
@@ -7,6 +7,9 @@
       name="description"
       content="Guaranteed 30 new patients in 90 days for aesthetic and surgical healthcare providers."
     />
+    <meta http-equiv="x-dns-prefetch-control" content="on" />
+    <link rel="preconnect" href="https://fast.vidalytics.com" crossorigin />
+    <link rel="dns-prefetch" href="//fast.vidalytics.com" />
     <link rel="canonical" href="https://revivesales.ai/cosmetic-surgeons" />
     <title>30 New Patients in 90 Days, Guaranteed | Revive</title>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css" />
@@ -70,113 +73,144 @@ src="https://www.facebook.com/tr?id=1619414729205128&ev=PageView&noscript=1"
     </style>
   </head>
   <body class="text-gray-900">
-    <header class="logo-bar py-10 md:py-12 px-4">
+    <header class="logo-bar py-9 md:py-10 px-4">
       <div class="hero-wrap flex items-center justify-center">
         <img src="/assets/revive-logo-DUfmYDna.png" alt="Revive" class="h-16 md:h-20 w-auto" />
       </div>
     </header>
 
-    <main class="py-14 md:py-20 px-4">
+    <main class="pt-8 md:pt-10 pb-14 md:pb-20 px-4">
       <section class="hero-wrap">
         <h1 class="text-center text-3xl md:text-5xl font-bold text-slate-900 leading-tight">
           Aesthetic and Surgical Healthcare Providers:
         </h1>
-        <h2 class="text-center text-3xl md:text-5xl font-bold text-slate-900 mt-6 md:mt-8 leading-tight">
+        <h2 class="text-center text-3xl md:text-5xl font-bold text-slate-900 mt-3 md:mt-4 leading-tight">
           We Guarantee <span class="text-green-600">30 New Patients</span> OR YOU DON'T PAY
         </h2>
 
-        <div class="mt-12 md:mt-16 video-shell">
+        <div class="mt-8 md:mt-10 video-shell">
           <div id="vidalytics_embed_HPGdKzkCWCw6QUNF" style="width: 100%; position: relative; padding-top: 56.25%"></div>
         </div>
 
-        <div class="mt-10 md:mt-12 flex flex-col sm:flex-row items-center justify-center gap-4">
+        <div class="mt-6 md:mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
           <a class="cta cta-primary w-full sm:w-auto" href="https://sales.revivesales.ai/book-call">Book a Strategy Call</a>
           <a class="cta bg-white border border-gray-300 w-full sm:w-auto" href="https://sales.revivesales.ai/book-call">Claim Your 30-Patient Guarantee</a>
         </div>
 
-        <article class="mt-12 bg-white border border-gray-200 rounded-2xl p-6 md:p-10 prose prose-lg max-w-none">
-          <h3>How This Works</h3>
-          <p>
-            Most aesthetic practices don’t actually have a lead generation problem. They have a follow-up capacity
-            problem. Revive helps your team respond to new leads instantly and re-engage cold leads consistently at scale.
-          </p>
-          <p>
-            If we do not help your practice generate 30 new patients in 90 days, you don’t pay. The guarantee is in writing.
-          </p>
-          <p>
-            If you’re ready to see whether your practice is a fit, book a call and we’ll walk you through the opportunity in
-            your current database.
-          </p>
-          <p>
-            <a class="cta cta-primary no-underline" href="https://sales.revivesales.ai/book-call">SCHEDULE CALL HERE</a>
-          </p>
+        <article class="mt-8 md:mt-10 bg-white border border-gray-200 rounded-2xl p-6 md:p-10">
+          <h3 class="text-3xl font-bold text-slate-900 text-center">How It Works</h3>
+
+          <div class="mt-6 space-y-6 text-lg md:text-xl leading-relaxed text-slate-800">
+            <section>
+              <h4 class="text-xl md:text-2xl font-semibold text-slate-900 mb-2">The Real Bottleneck</h4>
+              <p>
+                Most aesthetic practices don’t actually have a lead generation problem — they have a follow-up capacity
+                problem. Revive helps your team respond to new leads instantly and re-engage cold leads consistently at scale.
+              </p>
+            </section>
+
+            <section>
+              <h4 class="text-xl md:text-2xl font-semibold text-slate-900 mb-2">Our 30-Patient Guarantee</h4>
+              <p>
+                If we do not help your practice generate 30 new patients in 90 days, you don’t pay. The guarantee is in writing.
+              </p>
+            </section>
+
+            <section>
+              <h4 class="text-xl md:text-2xl font-semibold text-slate-900 mb-2">What Happens Next</h4>
+              <p>
+                If you’re ready to see whether your practice is a fit, book a call and we’ll walk you through the opportunity in
+                your current database.
+              </p>
+            </section>
+          </div>
+
+          <div class="mt-8 flex justify-center">
+            <a class="cta cta-primary no-underline w-full sm:w-auto" href="https://sales.revivesales.ai/book-call">SCHEDULE YOUR CALL</a>
+          </div>
         </article>
       </section>
     </main>
 
     <script type="text/javascript">
-      (function (v, i, d, a, l, y, t, c, s) {
-        y = '_' + d.toLowerCase();
-        c = d + 'L';
-        if (!v[d]) {
-          v[d] = {};
-        }
-        if (!v[c]) {
-          v[c] = {};
-        }
-        if (!v[y]) {
-          v[y] = {};
-        }
-        var vl = 'Loader',
-          vli = v[y][vl],
-          vsl = v[c][vl + 'Script'],
-          vlf = v[c][vl + 'Loaded'],
-          ve = 'Embed';
-        if (!vsl) {
-          vsl = function (u, cb) {
-            if (t) {
-              cb();
-              return;
-            }
-            s = i.createElement('script');
-            s.type = 'text/javascript';
-            s.async = 1;
-            s.src = u;
-            if (s.readyState) {
-              s.onreadystatechange = function () {
-                if (s.readyState === 'loaded' || s.readyState == 'complete') {
-                  s.onreadystatechange = null;
-                  vlf = 1;
+      (function () {
+        var embedId = 'vidalytics_embed_HPGdKzkCWCw6QUNF';
+        var embedLoaded = false;
+
+        function loadVidalytics() {
+          if (embedLoaded) return;
+          embedLoaded = true;
+
+          (function (v, i, d, a, l, y, t, c, s) {
+            y = '_' + d.toLowerCase();
+            c = d + 'L';
+            if (!v[d]) v[d] = {};
+            if (!v[c]) v[c] = {};
+            if (!v[y]) v[y] = {};
+            var vl = 'Loader',
+              vli = v[y][vl],
+              vsl = v[c][vl + 'Script'],
+              vlf = v[c][vl + 'Loaded'],
+              ve = 'Embed';
+            if (!vsl) {
+              vsl = function (u, cb) {
+                if (t) {
                   cb();
+                  return;
                 }
-              };
-            } else {
-              s.onload = function () {
-                vlf = 1;
-                cb();
+                s = i.createElement('script');
+                s.type = 'text/javascript';
+                s.async = 1;
+                s.src = u;
+                if (s.readyState) {
+                  s.onreadystatechange = function () {
+                    if (s.readyState === 'loaded' || s.readyState == 'complete') {
+                      s.onreadystatechange = null;
+                      vlf = 1;
+                      cb();
+                    }
+                  };
+                } else {
+                  s.onload = function () {
+                    vlf = 1;
+                    cb();
+                  };
+                }
+                i.getElementsByTagName('head')[0].appendChild(s);
               };
             }
-            i.getElementsByTagName('head')[0].appendChild(s);
-          };
+            vsl(l + 'loader.min.js', function () {
+              if (!vli) {
+                var vlc = v[c][vl];
+                vli = new vlc();
+              }
+              vli.loadScript(l + 'player.min.js', function () {
+                var vec = v[d][ve];
+                t = new vec();
+                t.run(a);
+              });
+            });
+          })(window, document, 'Vidalytics', embedId, 'https://fast.vidalytics.com/embeds/AALJpz_Y/HPGdKzkCWCw6QUNF/');
         }
-        vsl(l + 'loader.min.js', function () {
-          if (!vli) {
-            var vlc = v[c][vl];
-            vli = new vlc();
-          }
-          vli.loadScript(l + 'player.min.js', function () {
-            var vec = v[d][ve];
-            t = new vec();
-            t.run(a);
+
+        var videoTarget = document.getElementById(embedId);
+        if ('IntersectionObserver' in window && videoTarget) {
+          var observer = new IntersectionObserver(
+            function (entries) {
+              if (entries[0].isIntersecting) {
+                loadVidalytics();
+                observer.disconnect();
+              }
+            },
+            { rootMargin: '200px 0px' }
+          );
+          observer.observe(videoTarget);
+        } else {
+          window.addEventListener('load', function () {
+            setTimeout(loadVidalytics, 500);
           });
-        });
-      })(
-        window,
-        document,
-        'Vidalytics',
-        'vidalytics_embed_HPGdKzkCWCw6QUNF',
-        'https://fast.vidalytics.com/embeds/AALJpz_Y/HPGdKzkCWCw6QUNF/'
-      );
+        }
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Improve page performance by deferring the Vidalytics player load until the video container is near the viewport and by priming DNS/connectivity to the Vidalytics host. 
- Reduce excessive vertical spacing in the hero section and make the messaging/article copy clearer and easier to scan. 
- Simplify and harden the embed script to avoid double-loading and provide a safe fallback for older browsers.

### Description
- Added `<link rel="preconnect" crossorigin>` and `<link rel="dns-prefetch">` for `fast.vidalytics.com` and a `meta` tag to enable DNS prefetch control. 
- Adjusted layout spacing classes in the header and main hero (`py-`/`pt-`/`mt-` changes) to tighten vertical rhythm and reduced margins around the CTA and video. 
- Reworked the article section from a single prose block into structured, accessible subsections with headings and a centered CTA, and updated CTA text to `SCHEDULE YOUR CALL`. 
- Replaced the inline Vidalytics loader with a self-contained `loadVidalytics` function that guards against multiple loads, dynamically injects the loader/player scripts, and lazily triggers via `IntersectionObserver` (with a `200px` rootMargin) and a `load`+`setTimeout` fallback for environments without `IntersectionObserver`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41228db60832bb0de024dfe1f9ef8)