### PR TITLE
Enable Meta Pixel on cosmetic-surgeons page

### DIFF
--- a/cosmetic-surgeons.html
+++ b/cosmetic-surgeons.html
@@ -14,7 +14,7 @@
     <title>30 New Patients in 90 Days, Guaranteed | Revive</title>
     <link rel="stylesheet" crossorigin href="/assets/index-BW-gzsfY.css" />
     <!-- Meta Pixel Code -->
-    <!-- <script>
+<script>
 !function(f,b,e,v,n,t,s)
 {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
 n.callMethod.apply(n,arguments):n.queue.push(arguments)};
@@ -24,12 +24,12 @@ t.src=v;s=b.getElementsByTagName(e)[0];
 s.parentNode.insertBefore(t,s)}(window, document,'script',
 'https://connect.facebook.net/en_US/fbevents.js');
 fbq('init', '1619414729205128');
-fbq('track', 'ViewContent');
+fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
 src="https://www.facebook.com/tr?id=1619414729205128&ev=PageView&noscript=1"
-/></noscript> -->
-    <!-- End Meta Pixel Code -->
+/></noscript>
+<!-- End Meta Pixel Code -->
     <style>
       body {
         background: #f8fafc;


### PR DESCRIPTION
### Motivation
- Ensure the Meta Pixel actually fires on the `cosmetic-surgeons.html` page by installing the exact active snippet instead of a commented-out block.

### Description
- Re-enabled the Meta Pixel block in `cosmetic-surgeons.html` by removing the surrounding HTML comment, updated the event call to `fbq('track', 'PageView')`, and preserved the Pixel ID `1619414729205128` and the noscript beacon URL exactly as requested.

### Testing
- Ran repository searches and inspections with commands like `rg -n "cosmetic-surgeons\.html|fbq|fbevents|Meta Pixel|facebook.com/tr\?id=" -S .`, `git diff -- cosmetic-surgeons.html`, and viewed the file with `nl -ba cosmetic-surgeons.html | sed -n '12,36p'`, and all checks confirmed the active `PageView` script and noscript beacon were present (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f55d29dafc832b94199255ae16918a)